### PR TITLE
Update DriveService URLs to include '/ws/' prefix for API endpoints

### DIFF
--- a/pyicloud/services/drive.py
+++ b/pyicloud/services/drive.py
@@ -22,7 +22,6 @@ LOGGER: logging.Logger = logging.getLogger(__name__)
 
 COOKIE_APPLE_WEBAUTH_VALIDATE: str = "X-APPLE-WEBAUTH-VALIDATE"
 CLOUD_DOCS_ZONE: str = "com.apple.CloudDocs"
-CLOUD_DOCS: str = f"/ws/{CLOUD_DOCS_ZONE}"
 NODE_ROOT: str = "root"
 NODE_TRASH: str = "TRASH_ROOT"
 CLOUD_DOCS_ZONE_ID_ROOT: str = f"FOLDER::{CLOUD_DOCS_ZONE}::{NODE_ROOT}"
@@ -75,7 +74,7 @@ class DriveService(BaseService):
         file_params = dict(self.params)
         file_params.update({"document_id": file_id})
         response: Response = self.session.get(
-            self._document_root + f"{zone}/download/by_id",
+            self._document_root + f"/ws/{zone}/download/by_id",
             params=file_params,
         )
         self._raise_if_error(response)
@@ -117,7 +116,7 @@ class DriveService(BaseService):
         file_params.update(self._get_token_from_cookie())
 
         request: Response = self.session.post(
-            self._document_root + f"{zone}/upload/web",
+            self._document_root + f"/ws/{zone}/upload/web",
             params=file_params,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -170,7 +169,7 @@ class DriveService(BaseService):
             data["data"].update({"receipt": file_info["receipt"]})
 
         request: Response = self.session.post(
-            self._document_root + f"{zone}/update/documents",
+            self._document_root + f"/ws/{zone}/update/documents",
             params=self.params,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(data),

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -183,7 +183,7 @@ def test_get_file(pyicloud_service_working: PyiCloudService) -> None:
         file_response = drive.get_file("file_id")
         assert file_response.content == b"file content"
         mock_get.assert_any_call(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/download/by_id",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/download/by_id",
             params={**drive.params, "document_id": "file_id"},
         )
         mock_get.assert_any_call("https://example.com/file", params=drive.params)
@@ -348,7 +348,7 @@ def test_get_upload_contentws_url_success(
         assert url == "https://example.com/upload"
 
         mock_post.assert_called_once_with(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/upload/web",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/upload/web",
             params=ANY,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -388,7 +388,7 @@ def test_get_upload_contentws_url_no_content_type(
         assert url == "https://example.com/upload"
 
         mock_post.assert_called_once_with(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/upload/web",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/upload/web",
             params=ANY,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -421,7 +421,7 @@ def test_get_upload_contentws_url_error_response(
             drive._get_upload_contentws_url(mock_file)
 
         mock_post.assert_called_once_with(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/upload/web",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/upload/web",
             params=ANY,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -457,7 +457,7 @@ def test_get_upload_contentws_url_invalid_response_format(
             drive._get_upload_contentws_url(mock_file)
 
         mock_post.assert_called_once_with(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/upload/web",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/upload/web",
             params=ANY,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -510,7 +510,7 @@ def test_send_file_success(mock_service_with_cookies: PyiCloudService) -> None:
 
         # Assert _get_upload_contentws_url call
         mock_post.assert_any_call(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/upload/web",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/upload/web",
             params=ANY,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -531,7 +531,7 @@ def test_send_file_success(mock_service_with_cookies: PyiCloudService) -> None:
 
         # Assert _update_contentws call
         mock_post.assert_any_call(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/update/documents",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/update/documents",
             params=drive.params,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=ANY,
@@ -567,7 +567,7 @@ def test_send_file_upload_error(mock_service_with_cookies: PyiCloudService) -> N
 
         # Assert _get_upload_contentws_url call
         mock_post.assert_any_call(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/upload/web",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/upload/web",
             params=ANY,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -625,7 +625,7 @@ def test_send_file_update_error(mock_service_with_cookies: PyiCloudService) -> N
 
         # Assert _get_upload_contentws_url call
         mock_post.assert_any_call(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/upload/web",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/upload/web",
             params=ANY,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=json.dumps(
@@ -646,7 +646,7 @@ def test_send_file_update_error(mock_service_with_cookies: PyiCloudService) -> N
 
         # Assert _update_contentws call
         mock_post.assert_any_call(
-            drive._document_root + f"{CLOUD_DOCS_ZONE}/update/documents",
+            drive._document_root + f"/ws/{CLOUD_DOCS_ZONE}/update/documents",
             params=drive.params,
             headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             data=ANY,


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modify API endpoint URLs in the DriveService to include the '/ws/' prefix, ensuring consistency across all relevant requests and tests. This change enhances the structure of the API calls.

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #74
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
