### PR TITLE
security: Remove debug print statement exposing authentication tokens

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -337,7 +337,6 @@ class PyiCloudService(object):
                 "extended_login": True,
                 "trustToken": self.session.data.get("trust_token", ""),
             }
-            print(data)
 
             resp: Response = self.session.post(
                 f"{self.setup_endpoint}/accountLogin", json=data


### PR DESCRIPTION
Fixes #88 - Removes debug print(data) statement in _authenticate_with_token() method that was exposing dsWebAuthToken, trustToken, and accountCountryCode to stdout/logs. Debug statement was accidentally left from session refactoring in commit 73794a4.