### PR TITLE
calendar: fix monthrange misuse; use day=1 and days_in_month (fixes #116)

### DIFF
--- a/pyicloud/services/calendar.py
+++ b/pyicloud/services/calendar.py
@@ -517,9 +517,13 @@ class CalendarService(BaseService):
     def default_params(self) -> dict[str, Any]:
         """Returns the default parameters for the calendar service."""
         today: datetime = datetime.today()
-        first_day, last_day = monthrange(today.year, today.month)
-        from_dt = datetime(today.year, today.month, first_day)
-        to_dt = datetime(today.year, today.month, last_day)
+        _, days_in_month = monthrange(
+            today.year, today.month
+        )  # monthrange returns: weekday of the first day of the month (0 -> Mon, 6 -> Sun) and number of days in the month (Jan -> 31, Feb -> 28, etc.)
+        from_dt = datetime(
+            today.year, today.month, 1
+        )  # Hardcoded to 1 so that startDate is always the first (1st) day of the month
+        to_dt = datetime(today.year, today.month, days_in_month)
         params = dict(self.params)
         params.update(
             {
@@ -576,11 +580,15 @@ class CalendarService(BaseService):
         have been given, the range becomes this month.
         """
         today: datetime = datetime.today()
-        first_day, last_day = monthrange(today.year, today.month)
+        _, days_in_month = monthrange(
+            today.year, today.month
+        )  # monthrange returns: weekday of the first day of the month (0 -> Mon, 6 -> Sun) and number of days in the month (Jan -> 31, Feb -> 28, etc.)
         if not from_dt:
-            from_dt = datetime(today.year, today.month, first_day)
+            from_dt = datetime(
+                today.year, today.month, 1
+            )  # Hardcoded to 1 so that startDate is always the first (1st) day of the month
         if not to_dt:
-            to_dt = datetime(today.year, today.month, last_day)
+            to_dt = datetime(today.year, today.month, days_in_month)
         params = dict(self.params)
         params.update(
             {


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Summary**
- Fixes `ValueError: day is out of range for month` thrown by `CalendarService` when computing default date ranges.

**Root Cause**
- The code misused Python’s `calendar.monthrange(y, m)` which returns `(weekday_of_first_day, days_in_month)`.
- It treated the first value (weekday 0–6) as a day-of-month: `from_dt = datetime(y, m, first_day)`, causing a crash when weekday is Monday (`0`) and silently narrowing ranges otherwise.

**Changes**
- Compute month bounds correctly and consistently:
  - `_ , days_in_month = monthrange(y, m)`
  - `from_dt = datetime(y, m, 1)`
  - `to_dt = datetime(y, m, days_in_month)`
- **Applied in**:
  - `pyicloud/services/calendar.py: default_params`
  - `pyicloud/services/calendar.py: refresh_client`
- Removed the misleading `first_day` usage.

**Impact**
- Eliminates the exception for months starting on Monday.
- Ensures all month-based requests cover the full month (not the 2nd–7th).
- Affects callers that rely on default parameters: `get_calendars`, `add/remove_calendar`, `add/remove_event`, and `get_events` when `from_dt`/`to_dt` are omitted.
- External API remains unchanged.

**Verification**
- Local install (`uv pip install -e .`) and manual run:
  - `api.calendar.get_calendars(as_objs=True)` returns successfully.
  - `default_params['startDate']` is the 1st; `endDate` is the last day of the month.
- Pre-commit hooks passed.

**Risk**
- Low. Behavior is corrected to intended semantics (full-month window), no interface changes.

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
<!--
  Supplying a code snippet, makes it easier for a maintainer to test your PR.
  Furthermore, for new services, it gives an impression of how we should use it.
  Note: Remove this section for a dependency upgrade, a bugfix or code quality/test PR.
-->

```python
from pyicloud import PyiCloudService
api = PyiCloudService("<apple_id>")
calendars = api.calendar.get_calendars(as_objs=True) # bug occurred here
print(calendars)
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #116 
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
