### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,8 @@ name: Linting
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/timlaing/pyicloud/security/code-scanning/25](https://github.com/timlaing/pyicloud/security/code-scanning/25)

To fix the problem, we need to explicitly set the `permissions` key in the workflow to limit the GITHUB_TOKEN permissions according to the least privilege principle. Since the job only needs to check out code (`actions/checkout`) and run local Python linting commands, it is sufficient for the workflow to have only read access to repository contents. In practical terms, this involves adding `permissions: contents: read` at either the workflow root (just below the `name` and `on` sections) or under the specific `lint` job, but adding it at the root is simplest and applies to all jobs uniformly. No changes to existing functions or steps are necessary; only the insertion of the key is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
