### PR TITLE
fix: repair Notes folder desired keys

### DIFF
--- a/pyicloud/services/notes/service.py
+++ b/pyicloud/services/notes/service.py
@@ -56,6 +56,7 @@ from .models.constants import NotesDesiredKey, NotesRecordType
 from .models.dto import ChangeEvent, NoteFolder
 
 LOGGER = logging.getLogger(__name__)
+_HAS_SUBFOLDER_FIELD = "HasSubfolder"
 
 
 class NoteNotFound(NotesError):
@@ -248,8 +249,7 @@ class NotesService(BaseService):
         """
         desired_keys = [
             NotesDesiredKey.TITLE_ENCRYPTED,
-            NotesDesiredKey.TITLE_MODIFICATION_DATE,
-            NotesDesiredKey.HAS_SUBFOLDER,
+            _HAS_SUBFOLDER_FIELD,
         ]
         query = CKQueryObject(
             recordType="SearchIndexes",
@@ -277,13 +277,12 @@ class NotesService(BaseService):
                     name = self._decode_encrypted(
                         rec.fields.get_value("TitleEncrypted")
                     )
-                    has_sub = bool(
-                        getattr(
-                            rec.fields.get_field(NotesDesiredKey.HAS_SUBFOLDER) or (),
-                            "value",
-                            False,
-                        )
+                    has_sub_value = getattr(
+                        rec.fields.get_field(_HAS_SUBFOLDER_FIELD) or (),
+                        "value",
+                        None,
                     )
+                    has_sub = None if has_sub_value is None else bool(has_sub_value)
                     yield NoteFolder(
                         id=folder_id, name=name, has_subfolders=has_sub, count=None
                     )

--- a/pyicloud/services/notes/service.py
+++ b/pyicloud/services/notes/service.py
@@ -277,11 +277,7 @@ class NotesService(BaseService):
                     name = self._decode_encrypted(
                         rec.fields.get_value("TitleEncrypted")
                     )
-                    has_sub_value = getattr(
-                        rec.fields.get_field(_HAS_SUBFOLDER_FIELD) or (),
-                        "value",
-                        None,
-                    )
+                    has_sub_value = rec.fields.get_value(_HAS_SUBFOLDER_FIELD)
                     has_sub = None if has_sub_value is None else bool(has_sub_value)
                     yield NoteFolder(
                         id=folder_id, name=name, has_subfolders=has_sub, count=None

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -306,6 +306,64 @@ class NotesServiceTest(unittest.TestCase):
         self.assertEqual(attachments[0].id, "Attachment/CANONICAL")
         self.assertIs(self.service._attachment_meta_cache["ALIAS-1"], attachments[0])
 
+    def test_notes_service_folders_uses_supported_desired_keys(self):
+        """Folder listing should not depend on nonexistent Notes desired-key enums."""
+
+        folder_record = CKRecord.model_validate(
+            {
+                "recordName": "Folder/1",
+                "recordType": "SearchIndexes",
+                "fields": {
+                    "TitleEncrypted": {
+                        "type": "STRING",
+                        "value": "Work",
+                        "isEncrypted": True,
+                    },
+                    "HasSubfolder": {"type": "INT64", "value": 1},
+                },
+            }
+        )
+        self.service.raw.query = MagicMock(
+            return_value=MagicMock(records=[folder_record], continuationMarker=None)
+        )
+
+        folders = list(self.service.folders())
+
+        self.assertEqual(
+            self.service.raw.query.call_args.kwargs["desired_keys"],
+            ["TitleEncrypted", "HasSubfolder"],
+        )
+        self.assertEqual(len(folders), 1)
+        self.assertEqual(folders[0].id, "Folder/1")
+        self.assertEqual(folders[0].name, "Work")
+        self.assertTrue(folders[0].has_subfolders)
+
+    def test_notes_service_folders_treats_subfolder_flag_as_optional(self):
+        """Folder listing should still work when Apple omits the subfolder flag."""
+
+        folder_record = CKRecord.model_validate(
+            {
+                "recordName": "Folder/2",
+                "recordType": "SearchIndexes",
+                "fields": {
+                    "TitleEncrypted": {
+                        "type": "STRING",
+                        "value": "Personal",
+                        "isEncrypted": True,
+                    },
+                },
+            }
+        )
+        self.service.raw.query = MagicMock(
+            return_value=MagicMock(records=[folder_record], continuationMarker=None)
+        )
+
+        folders = list(self.service.folders())
+
+        self.assertEqual(len(folders), 1)
+        self.assertEqual(folders[0].name, "Personal")
+        self.assertIsNone(folders[0].has_subfolders)
+
     def test_write_html_rejects_filename_escape(self):
         out_dir = os.path.join(
             tempfile.gettempdir(),


### PR DESCRIPTION
## Summary

This fixes a Notes service bug in `NotesService.folders()`.

`folders()` referenced `NotesDesiredKey.TITLE_MODIFICATION_DATE` and `NotesDesiredKey.HAS_SUBFOLDER`, but those enum members do not exist. That caused folder listing to raise `AttributeError` before the query could complete.

This change fixes the crash by:

- removing the invalid desired-key enum references from `NotesService.folders()`
- requesting the supported encrypted title field and the optional raw `HasSubfolder` field directly
- treating the subfolder flag as optional when Apple omits it
- adding focused regression coverage for the desired-key set and missing subfolder metadata

## Impact

- folder queries no longer fail before reaching CloudKit
- callers can list note folders even when the subfolder flag is absent from the payload
- this is a service-layer fix and does not depend on the new Notes CLI branch

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache PATH=$HOME/.local/bin:$PATH UV_NO_EDITABLE=1 uv run --no-sync ruff check pyicloud/services/notes/service.py tests/test_notes.py`
- `UV_CACHE_DIR=/tmp/uv-cache PATH=$HOME/.local/bin:$PATH UV_NO_EDITABLE=1 uv run --no-sync python -m pytest tests/test_notes.py -q`
- manual smoke test: `notes folders` stopped crashing when this fix was applied onto the CLI branch
