### PR TITLE
feat: add a root `--version` CLI flag

### DIFF
--- a/pyicloud/cli/app.py
+++ b/pyicloud/cli/app.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+
 import typer
 
 from pyicloud.cli.commands.account import app as account_app
@@ -21,12 +24,42 @@ app = typer.Typer(
 )
 
 
+def _installed_version() -> str:
+    """Return the installed pyicloud package version."""
+
+    try:
+        return package_version("pyicloud")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _version_callback(value: bool) -> None:
+    """Print the installed pyicloud version and exit."""
+
+    if value:
+        typer.echo(_installed_version())
+        raise typer.Exit()
+
+
 def _group_root(ctx: typer.Context) -> None:
     """Show mounted group help when invoked without a subcommand."""
 
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
         raise typer.Exit()
+
+
+@app.callback()
+def root_callback(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show the installed pyicloud version and exit.",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """Handle root CLI options before subcommand dispatch."""
 
 
 app.add_typer(

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -525,6 +525,16 @@ def test_root_help() -> None:
         assert command in text
 
 
+def test_root_version_prints_installed_package_version() -> None:
+    """The root --version flag should print the installed pyicloud version."""
+
+    with patch.object(cli_module, "_installed_version", return_value="9.9.9"):
+        result = _runner().invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "9.9.9"
+
+
 def test_group_help() -> None:
     """Each command group should expose help."""
 


### PR DESCRIPTION
## Proposed change

This PR adds a root-level `--version` flag to the `icloud` CLI.

Running `icloud --version` now prints the installed `pyicloud` package version and exits without requiring a subcommand. The implementation resolves the version from installed package metadata so the output matches the actual installed distribution rather than a hard-coded string.

This keeps the change small and focused:
- add a root CLI callback for `--version`
- print the installed `pyicloud` version and exit early
- add a focused CLI test covering the new flag

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:

```python
# CLI usage
# icloud --version
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Local validation:
  - `uv run --no-sync python -m pytest tests/test_cmdline.py -q`
  - `uv run --no-sync ruff check pyicloud/cli/app.py tests/test_cmdline.py`
  - `uv run --no-sync python -m pyicloud.cmdline --version` -> `2.4.2.dev11`

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README