### PR TITLE
fix: error running `account summary` with no family members

### DIFF
--- a/pyicloud/services/account.py
+++ b/pyicloud/services/account.py
@@ -71,7 +71,7 @@ class AccountService(BaseService):
             )
             response = req.json()
 
-            for member_info in response["familyMembers"]:
+            for member_info in response.get("familyMembers", []):
                 self._family.append(
                     FamilyMember(
                         member_info,

--- a/tests/services/test_account.py
+++ b/tests/services/test_account.py
@@ -5,7 +5,7 @@
 from unittest.mock import MagicMock
 
 from pyicloud import PyiCloudService
-from pyicloud.services.account import AccountStorageUsage
+from pyicloud.services.account import AccountService, AccountStorageUsage
 
 
 def test_repr(pyicloud_service_working: PyiCloudService) -> None:
@@ -72,6 +72,18 @@ def test_family(pyicloud_service_working: PyiCloudService) -> None:
             + member.age_classification
             + "}>"
         )
+
+
+def test_family_missing_key(mock_session: MagicMock) -> None:
+    """family returns [] when familyMembers key is absent from response."""
+    mock_session.get.return_value.json.return_value = {}
+    service = AccountService(
+        service_root="https://example.com",
+        session=mock_session,
+        china_mainland=False,
+        params={},
+    )
+    assert service.family == []
 
 
 def test_storage(pyicloud_service_working: PyiCloudService) -> None:


### PR DESCRIPTION
Fixing the error when running `icloud account summary` - apparently `familyMembers` is optional key in that response.

```
╭────────────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────────╮
│ /home/pyicloud/pyicloud/cli/commands/account.py:59 in account_summary
│
│    56 │   account = service_call(
│    57 │   │   "Account", lambda: api.account, account_name=api.account_name
│    58 │   )
│ ❱  59 │   payload = normalize_account_summary(api, account)
│    60 │   if state.json_output:
│    61 │   │   state.write_json(payload)
│    62 │   │   return
│
│ /home/pyicloud/pyicloud/cli/normalize.py:18 in normalize_account_summary
│
│    15 │   return {
│    16 │   │   "account_name": api.account_name,
│    17 │   │   "devices_count": len(account.devices),
│ ❱  18 │   │   "family_count": len(account.family),
│    19 │   │   "used_storage_bytes": storage.usage.used_storage_in_bytes,
│    20 │   │   "available_storage_bytes": storage.usage.available_storage_in_bytes,
│    21 │   │   "total_storage_bytes": storage.usage.total_storage_in_bytes,
│
│ /home/pyicloud/pyicloud/services/account.py:74 in family
│
│    71 │   │   │   )
│    72 │   │   │   response = req.json()
│    73 │   │   │
│ ❱  74 │   │   │   for member_info in response["familyMembers"]:
│    75 │   │   │   │   self._family.append(
│    76 │   │   │   │   │   FamilyMember(
│    77 │   │   │   │   │   │   member_info,
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'familyMembers'
```

<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample



## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
