### PR TITLE
Stop retrying permanently-LOADING family members without location sharing

### DIFF
--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -103,29 +103,37 @@ class FindMyiPhoneServiceManager(BaseService):
     def _initialize_devices(self, locate: bool) -> None:
         """Initializes the devices for the FindMyiPhoneServiceManager."""
 
-        # If family sharing is enabled, we may need to poll until all devices are ready
-        # This is indicated by the deviceFetchStatus being "LOADING"
+        # If family sharing is enabled, we may need to poll until all devices are ready.
+        # This is indicated by the deviceFetchStatus being "LOADING".
+        # Some members (e.g. Macs with location sharing disabled) remain permanently
+        # LOADING and will never resolve. Track which members are LOADING between
+        # retries and stop as soon as there is no progress, rather than always
+        # exhausting _MAX_REFRESH_RETRIES for stuck members.
         retries: int = 0
+        prev_loading_keys: set[str] = set()
         while (
             self._with_family
             and self._user_info
             and self._user_info.get("hasMembers", False)
+            and retries < _MAX_REFRESH_RETRIES
         ):
-            needs_refresh: bool = False
-            for user in self._user_info.get("membersInfo", {}).values():
-                if user.get("deviceFetchStatus") == "LOADING":
-                    needs_refresh = True
-                    break
-
-            if needs_refresh:
-                time.sleep(0.1)
-                self._refresh_client(locate=locate)
-                retries += 1
-                if retries >= _MAX_REFRESH_RETRIES:
-                    _LOGGER.debug("Max retries reached when fetching family devices")
-                    break
-            else:
-                break
+            loading_keys = {
+                k
+                for k, v in self._user_info.get("membersInfo", {}).items()
+                if v.get("deviceFetchStatus") == "LOADING"
+            }
+            if not loading_keys:
+                break  # all family members ready
+            if loading_keys == prev_loading_keys:
+                _LOGGER.debug(
+                    "No progress on LOADING family members after retry %d, stopping",
+                    retries,
+                )
+                break  # no change since last retry — give up on permanently stuck members
+            prev_loading_keys = loading_keys
+            time.sleep(0.1)
+            self._refresh_client(locate=locate)
+            retries += 1
 
         if not self._devices:
             raise PyiCloudNoDevicesException()

--- a/tests/services/test_findmyiphone.py
+++ b/tests/services/test_findmyiphone.py
@@ -691,7 +691,12 @@ def test_refresh_client_with_reauth_with_loading_to_done(
 def test_refresh_client_with_reauth_with_loading_no_complete(
     pyicloud_service_working: PyiCloudService,
 ) -> None:
-    """Test refresh_client_with_reauth calls _refresh_client if the members are loading."""
+    """Test that the retry loop stops as soon as no LOADING members make progress.
+
+    member2 resolves after the first retry (progress made → continue).
+    member1 remains LOADING after the second retry (no change → stop early).
+    Total refresh calls: 1 initial + 2 loop iterations = 3.
+    """
     with patch(
         "pyicloud.services.findmyiphone.FindMyiPhoneServiceManager._refresh_client_with_reauth",
         return_value=None,
@@ -753,69 +758,9 @@ def test_refresh_client_with_reauth_with_loading_no_complete(
                     "deviceFetchStatus": "DONE",
                 },
             },
-            True,
-            {
-                "member1": {
-                    "firstName": "Member1",
-                    "lastName": "One",
-                    "appleId": "member1@example.com",
-                    "deviceFetchStatus": "LOADING",
-                },
-                "member2": {
-                    "firstName": "Member2",
-                    "lastName": "Two",
-                    "appleId": "member2@example.com",
-                    "deviceFetchStatus": "DONE",
-                },
-            },
-            True,
-            {
-                "member1": {
-                    "firstName": "Member1",
-                    "lastName": "One",
-                    "appleId": "member1@example.com",
-                    "deviceFetchStatus": "LOADING",
-                },
-                "member2": {
-                    "firstName": "Member2",
-                    "lastName": "Two",
-                    "appleId": "member2@example.com",
-                    "deviceFetchStatus": "DONE",
-                },
-            },
-            True,
-            {
-                "member1": {
-                    "firstName": "Member1",
-                    "lastName": "One",
-                    "appleId": "member1@example.com",
-                    "deviceFetchStatus": "DONE",
-                },
-                "member2": {
-                    "firstName": "Member2",
-                    "lastName": "Two",
-                    "appleId": "member2@example.com",
-                    "deviceFetchStatus": "DONE",
-                },
-            },
-            True,
-            {
-                "member1": {
-                    "firstName": "Member1",
-                    "lastName": "One",
-                    "appleId": "member1@example.com",
-                    "deviceFetchStatus": "LOADING",
-                },
-                "member2": {
-                    "firstName": "Member2",
-                    "lastName": "Two",
-                    "appleId": "member2@example.com",
-                    "deviceFetchStatus": "DONE",
-                },
-            },
         ]
         manager._refresh_client_with_reauth(locate=True)
-        assert mock_refresh.call_count == 6
+        assert mock_refresh.call_count == 3
         mock_refresh.assert_called_with(locate=True)
 
 


### PR DESCRIPTION
## Problem

The `_initialize_devices()` retry loop polls until all family members leave the `LOADING` state or `_MAX_REFRESH_RETRIES` is exhausted. Family members with location sharing disabled (e.g. a Mac where the user has turned off Share My Location) return `deviceFetchStatus: LOADING` **permanently** — they never resolve.

This caused the loop to always exhaust all 5 retries and log:
```
Max retries reached when fetching family devices
```
on **every single poll cycle**, generating constant log noise and unnecessary API calls.

## Root cause

The loop only tracked retry count, not whether any progress was made between retries. A permanently-stuck member looks identical to a slow-resolving member until all retries are spent.

The FMIP `membersInfo` payload contains no field indicating whether a member has location sharing enabled (only `accountFormatter`, `firstName`, `lastName`, `deviceFetchStatus`, `useAuthWidget`, `isHSA`, `appleId`), so the member cannot be filtered out by capability.

## Fix

Track which member keys are `LOADING` between retries. If the set of `LOADING` members hasn't changed after a retry, those members will not resolve on further retries — stop early.

```
Retry 0: {MacBook} LOADING → retry (progress possible)
Retry 1: {MacBook} LOADING → same as before → stop
```

For a transient member that does resolve (e.g. an iPhone waking up):
```
Retry 0: {iPhone, MacBook} LOADING → retry (progress possible)
Retry 1: {MacBook} LOADING → set changed → retry (iPhone resolved!)
Retry 2: {MacBook} LOADING → same as before → stop
```

## Result

- Permanently-stuck members cause at most 2 retries (vs. always 5) before exiting cleanly
- Transient members that do resolve still get up to `_MAX_REFRESH_RETRIES` attempts
- No more "Max retries reached" log spam on every poll cycle
- Tested with Home Assistant 2026.4.3, family account with one member (Mac) that has location sharing permanently disabled

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

Co-authored with Claude Sonnet 4.6