### PR TITLE
Pin workspace Python interpreter to project .venv

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,8 @@
   "python.analysis.diagnosticMode": "openFilesOnly",
   "sonarlint.testFilePattern": "**/tests/**",
   "python.languageServer": "Pylance",
+  // Windows contributors: this Unix-style path won't resolve. Override locally
+  // (e.g. via User Settings or the interpreter picker) to
+  // "${workspaceFolder}/.venv/Scripts/python.exe".
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,6 @@
   "pylint.importStrategy": "fromEnvironment",
   "python.analysis.diagnosticMode": "openFilesOnly",
   "sonarlint.testFilePattern": "**/tests/**",
-  "python.languageServer": "Pylance"
+  "python.languageServer": "Pylance",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }


### PR DESCRIPTION
## Proposed change

Adds `"python.defaultInterpreterPath": "\${workspaceFolder}/.venv/bin/python"` to [`.vscode/settings.json`](.vscode/settings.json) so the VS Code Python extension consistently resolves this workspace's interpreter on reload.

Without an explicit workspace-level pin, the picker selection is transient and the extension can fall back to a user-level `python.defaultInterpreterPath` that points at an unrelated project's venv. Combined with the existing `"python.terminal.activateEnvInCurrentTerminal": true`, that causes integrated terminals to silently activate the wrong venv on window reload, which makes `uv pip install` and type checkers (e.g. Pyrefly) target the wrong site-packages.

The setting follows the common Python convention of a `.venv/` at the repo root. Contributors using a different venv location can override locally via the interpreter picker. A JSONC comment above the line documents the Windows equivalent path (per CodeRabbit feedback already addressed).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works. (Workspace config; no test surface.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)