### PR TITLE
Fix bytes|str narrowing in HSA2 bridge; add types-requests dev dep

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from os import chmod, environ, makedirs, path, umask
 from tempfile import gettempdir
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, cast
 from uuid import uuid1
 
 import srp
@@ -964,8 +964,9 @@ class PyiCloudService:
                     auth_endpoint=self._auth_endpoint,
                     headers=self._get_auth_headers({"Accept": CONTENT_TYPE_JSON}),
                     boot_context=self._current_hsa2_boot_context(),
-                    user_agent=self.session.headers.get(
-                        "User-Agent", _HEADERS["User-Agent"]
+                    user_agent=cast(
+                        str,
+                        self.session.headers.get("User-Agent", _HEADERS["User-Agent"]),
                     ),
                 )
                 self._set_two_factor_delivery_state("trusted_device")

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ pytest>=8.3.5
 pytest-cov>=7.1.0
 pytest-socket>=0.6.0
 ruff>=0.9.9
+types-requests>=2.32.0


### PR DESCRIPTION
## Proposed change

Clears three Pyrefly diagnostics in [`pyicloud/base.py`](pyicloud/base.py) with no runtime behavior change:

- **`bad-argument-type`** — wraps `self.session.headers.get("User-Agent", _HEADERS["User-Agent"])` in `typing.cast(str, ...)` at the `TrustedDeviceBridgeBootstrapper.start()` call site. `requests.Session.headers` (a `CaseInsensitiveDict`) is typed as returning `bytes | str`, but `start()` requires `str`. In practice the header is always a `str` at runtime; the cast narrows the type without changing behavior.
- **`untyped-import` ×2** — adds `types-requests>=2.32.0` to [`requirements_test.txt`](requirements_test.txt) so type checkers have stubs for the `requests` library (no longer warns on `requests` / `requests.models` imports).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works. (No new test surface — `cast` is identity at runtime; the existing 2FA / HSA2 bridge tests exercise the call path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)