### PR TITLE
docs: add missing docstrings to pyicloud and tests modules

### DIFF
--- a/pyicloud/common/cloudkit/base.py
+++ b/pyicloud/common/cloudkit/base.py
@@ -1,3 +1,5 @@
+"""Configuration and base models for CloudKit validation."""
+
 from __future__ import annotations
 
 import os

--- a/pyicloud/common/cloudkit/models.py
+++ b/pyicloud/common/cloudkit/models.py
@@ -139,6 +139,8 @@ SecsOrMillisDateTime = Annotated[
 
 
 class CKZoneID(CKModel):
+    """Identifies a CloudKit zone by name, owner, and optional type."""
+
     zoneName: str
     ownerRecordName: Optional[str] = None
     zoneType: Optional[str] = None
@@ -155,10 +157,14 @@ class CKAuditInfo(CKModel):
 
 
 class CKParent(CKModel):
+    """References a parent record in a record hierarchy."""
+
     recordName: str
 
 
 class CKStableUrl(CKModel):
+    """Secure URL and access credentials for sharing a record."""
+
     routingKey: Optional[str] = None
     shortTokenHash: Optional[str] = None
     protectedFullToken: Optional[str] = None
@@ -167,6 +173,8 @@ class CKStableUrl(CKModel):
 
 
 class CKChainProtectionInfo(CKModel):
+    """End-to-end encryption chain protection metadata."""
+
     bytes: Optional[Base64Bytes] = None  # base64 string as seen on wire
     pcsChangeTag: Optional[str] = None
 
@@ -189,16 +197,22 @@ class CKShare(CKModel):
 
 
 class CKNameComponents(CKModel):
+    """User's name split into given and family names."""
+
     givenName: Optional[str] = None
     familyName: Optional[str] = None
 
 
 class CKLookupInfo(CKModel):
+    """Contact information for user lookup (email or phone)."""
+
     emailAddress: Optional[str] = None
     phoneNumber: Optional[str] = None
 
 
 class CKUserIdentity(CKModel):
+    """Complete user identity with name and contact information."""
+
     userRecordName: Optional[str] = None
     nameComponents: Optional[CKNameComponents] = None
     lookupInfo: Optional[CKLookupInfo] = None
@@ -209,6 +223,8 @@ class CKParticipantProtectionInfo(CKChainProtectionInfo):
 
 
 class CKParticipant(CKModel):
+    """Person sharing a record with permissions, status, and protection info."""
+
     participantId: Optional[str] = None
     userIdentity: Optional[CKUserIdentity] = None
     type: Optional[str] = None
@@ -243,12 +259,16 @@ class CKReference(CKModel):
 
 
 class _CKFieldBase(CKModel):
+    """Base class for CloudKit field type wrappers with discriminator support."""
+
     # Every field wrapper has a 'type' discriminator and a 'value'
     # Subclasses declare type: Literal[...] for the discriminator.
     pass
 
 
 class CKTimestampField(_CKFieldBase):
+    """Milliseconds-since-epoch timestamp field wrapper."""
+
     type: Literal["TIMESTAMP"]
     value: (
         MillisDateTimeOrNone  # Apple sometimes sends a "zero" ms sentinel; map to None
@@ -256,21 +276,29 @@ class CKTimestampField(_CKFieldBase):
 
 
 class CKInt64Field(_CKFieldBase):
+    """64-bit signed integer field wrapper."""
+
     type: Literal["INT64"]
     value: int
 
 
 class CKEncryptedBytesField(_CKFieldBase):
+    """Base64-encoded encrypted binary field wrapper."""
+
     type: Literal["ENCRYPTED_BYTES"]
     value: Base64Bytes
 
 
 class CKReferenceField(_CKFieldBase):
+    """Reference to another CloudKit record."""
+
     type: Literal["REFERENCE"]
     value: Optional[CKReference]
 
 
 class CKReferenceListField(_CKFieldBase):
+    """List of references to other CloudKit records."""
+
     type: Literal["REFERENCE_LIST"]
     value: List[CKReference]
 
@@ -278,18 +306,24 @@ class CKReferenceListField(_CKFieldBase):
 # Occasionally CloudKit also uses STRING-typed wrappers at the `fields` level;
 # keep support here for completeness.
 class CKStringField(_CKFieldBase):
+    """String value field wrapper, optionally encrypted."""
+
     type: Literal["STRING"]
     value: Optional[str]
     isEncrypted: Optional[bool] = None  # seen on some STRING wrappers (lookup)
 
 
 class CKStringListField(_CKFieldBase):
+    """List of string values field wrapper."""
+
     type: Literal["STRING_LIST"]
     value: List[str]
 
 
 # Asset thumbnails / tokens (e.g. FirstAttachmentThumbnail)
 class CKAssetToken(CKModel):
+    """Asset token with download URL, checksums, and wrapping key."""
+
     # Keep as str to preserve exact wire representation.
     fileChecksum: Optional[str] = None
     referenceChecksum: Optional[str] = None
@@ -300,17 +334,23 @@ class CKAssetToken(CKModel):
 
 
 class CKAssetIDField(_CKFieldBase):
+    """Asset ID field wrapper referencing an asset by token."""
+
     type: Literal["ASSETID"]
     value: CKAssetToken
 
 
 # Optional but seen in other CK APIs
 class CKAssetField(_CKFieldBase):
+    """Asset field wrapper for inline asset data."""
+
     type: Literal["ASSET"]
     value: CKAssetToken
 
 
 class CKDoubleField(_CKFieldBase):
+    """Floating-point field wrapper, optionally encrypted (e.g. for location data)."""
+
     type: Literal["DOUBLE"]
     value: float
     # AlarmTrigger latitude/longitude in Reminders can be encrypted doubles.
@@ -318,34 +358,46 @@ class CKDoubleField(_CKFieldBase):
 
 
 class CKBytesField(_CKFieldBase):
+    """Raw binary field wrapper as base64-encoded bytes."""
+
     # Raw bytes seen on wire (e.g., LastViewedTimestamp, CryptoPassphraseVerifier)
     type: Literal["BYTES"]
     value: Base64Bytes
 
 
 class CKDoubleListField(_CKFieldBase):
+    """List of floating-point values field wrapper."""
+
     type: Literal["DOUBLE_LIST"]
     value: List[float]
 
 
 class CKInt64ListField(_CKFieldBase):
+    """List of 64-bit integer values field wrapper."""
+
     type: Literal["INT64_LIST"]
     value: List[int]
 
 
 class CKAssetIDListField(_CKFieldBase):
+    """List of asset ID tokens field wrapper."""
+
     # e.g., PreviewImages, PaperAssets (most cases)
     type: Literal["ASSETID_LIST"]
     value: List[CKAssetToken]
 
 
 class CKUnknownListField(_CKFieldBase):
+    """Fallback list field wrapper for unexpected CloudKit types."""
+
     # Extremely rare: observed on some PaperAssets payloads as UNKNOWN_LIST.
     type: Literal["UNKNOWN_LIST"]
     value: List[JsonValue]  # keep generic to be future-proof
 
 
 class CKPassthroughField(_CKFieldBase):
+    """Generic field wrapper for unknown or future CloudKit field types."""
+
     type: str
     value: JsonValue
 
@@ -435,11 +487,13 @@ class CKFieldOpen(RootModel[Union[KnownCKField, CKPassthroughField]]):
 
     @property
     def value(self):
+        """Retrieve the inner value from the field wrapper."""
         # unified way to read the inner 'value' without touching .root
         return getattr(self.root, "value", None)
 
     @property
     def type_tag(self) -> Optional[str]:
+        """Retrieve the CloudKit type discriminator from the field wrapper."""
         # useful when inspecting unknown/passthrough fields
         return getattr(self.root, "type", None)
 
@@ -498,16 +552,19 @@ class CKFields(dict[str, CKFieldOpen]):
     """
 
     def __getattr__(self, name: str) -> CKFieldOpen:
+        """Retrieve field value by attribute name instead of dictionary key."""
         try:
             return dict.__getitem__(self, name)
         except KeyError as e:
             raise AttributeError(name) from e
 
     def __dir__(self):
+        """List available field names for attribute access."""
         base = set(super().__dir__())
         return sorted(base | set(self.keys()))
 
     def get_field(self, key: str):
+        """Retrieve the inner typed field wrapper for isinstance checks."""
         f = self.get(key)
         if f is None:
             return None
@@ -515,6 +572,7 @@ class CKFields(dict[str, CKFieldOpen]):
         return f.unwrap() if hasattr(f, "unwrap") else f
 
     def get_value(self, key: str):
+        """Retrieve the decoded value of a field by key."""
         f = self.get_field(key)
         return None if f is None else getattr(f, "value", None)
 
@@ -633,7 +691,9 @@ class CKWriteParent(CKModel):
 
 
 class CKWriteFields(CKFields):
-    """Write-side field mapping for modify requests."""
+    """Field mapping specialized for CloudKit record modify requests."""
+
+    pass
 
 
 class CKWriteRecord(CKModel):
@@ -655,6 +715,7 @@ class CKWriteRecord(CKModel):
     @field_validator("fields", mode="before")
     @classmethod
     def _coerce_fields(cls, v):
+        """Convert raw field mapping into typed CKWriteFields container."""
         return _coerce_field_mapping(v, CKWriteFields)
 
 
@@ -711,6 +772,8 @@ class CKQueryResponse(CKModel):
 
 # Comparators seen on the wire. Keep Union[str, Enum] to be forward-compatible.
 class CKComparator(str, Enum):
+    """CloudKit query filter comparison operators."""
+
     EQUALS = "EQUALS"
     IN_ = "IN"  # 'IN' is a reserved word in Python, keep name distinct
     CONTAINS_ANY = "CONTAINS_ANY"
@@ -724,30 +787,42 @@ class CKComparator(str, Enum):
 
 # FieldValue typed wrappers (request side) — discriminated by 'type'
 class _CKFilterValueBase(CKModel):
+    """Base class for filter value wrappers with type discriminator."""
+
     pass  # Subclasses declare type: Literal[...] for the discriminator.
 
 
 class CKFVString(_CKFilterValueBase):
+    """String literal value in a query filter."""
+
     type: Literal["STRING"]
     value: str
 
 
 class CKFVInt64(_CKFilterValueBase):
+    """Integer literal value in a query filter."""
+
     type: Literal["INT64"]
     value: int
 
 
 class CKFVStringList(_CKFilterValueBase):
+    """List of string values in a query filter."""
+
     type: Literal["STRING_LIST"]
     value: List[str]
 
 
 class CKFVReference(_CKFilterValueBase):
+    """Record reference value in a query filter."""
+
     type: Literal["REFERENCE"]
     value: CKReference  # zoneID is optional in observed payloads
 
 
 class CKFVReferenceList(_CKFilterValueBase):
+    """List of record references in a query filter."""
+
     type: Literal["REFERENCE_LIST"]
     value: List[CKReference]
 
@@ -810,6 +885,8 @@ class CKQueryObject(CKModel):
 
 # Request side (only what you actually send on the wire)
 class CKZoneIDReq(CKModel):
+    """Zone identifier for requests (without redundant fields)."""
+
     zoneName: str
     zoneType: Optional[str] = None
     ownerRecordName: Optional[str] = None
@@ -835,6 +912,8 @@ class CKQueryRequest(CKModel):
 
 
 class CKLookupDescriptor(CKModel):
+    """Specifies a record to fetch by name."""
+
     recordName: str
 
 
@@ -844,12 +923,16 @@ class CKLookupDescriptor(CKModel):
 
 
 class CKLookupRequest(CKModel):
+    """Payload for fetching specific records by their names."""
+
     records: List[CKLookupDescriptor]
     zoneID: CKZoneIDReq
     desiredKeys: Optional[List[str]] = None
 
 
 class CKLookupResponse(CKModel):
+    """Response containing records fetched by lookup request."""
+
     records: List[Union[CKRecord, CKTombstoneRecord, CKErrorItem]]
     # Server returns a top-level syncToken when getCurrentSyncToken=true
     syncToken: Optional[str] = None
@@ -955,6 +1038,8 @@ class CKZoneChangesZoneReq(CKModel):
 
 
 class CKZoneChangesRequest(CKModel):
+    """Payload for fetching zone changes since a specific sync token."""
+
     zones: List[CKZoneChangesZoneReq]
     resultsLimit: Optional[int] = None
 
@@ -965,6 +1050,8 @@ class CKZoneChangesRequest(CKModel):
 
 
 class CKModifyOperation(CKModel):
+    """Single record operation in a modify request (create/update/delete)."""
+
     operationType: Literal[
         "create",
         "update",
@@ -978,12 +1065,16 @@ class CKModifyOperation(CKModel):
 
 
 class CKModifyRequest(CKModel):
+    """Payload for modifying records in a zone."""
+
     operations: List[CKModifyOperation]
     zoneID: CKZoneIDReq
     atomic: Optional[bool] = None
 
 
 class CKModifyResponse(CKModel):
+    """Response containing records after modification operations."""
+
     records: List[Union[CKRecord, CKTombstoneRecord, CKErrorItem]] = Field(
         default_factory=list
     )

--- a/pyicloud/services/invites/models/dto.py
+++ b/pyicloud/services/invites/models/dto.py
@@ -35,6 +35,8 @@ class ParticipantType(str, Enum):
 
 
 class AcceptanceStatus(str, Enum):
+    """Guest's acceptance status for an invitation."""
+
     ACCEPTED = "ACCEPTED"
     INVITED = "INVITED"
     REMOVED = "REMOVED"

--- a/pyicloud/services/notes/decoding.py
+++ b/pyicloud/services/notes/decoding.py
@@ -1,3 +1,5 @@
+"""Decoding of compressed note data from TextDataEncrypted format."""
+
 from __future__ import annotations
 
 import base64

--- a/pyicloud/services/notes/domain.py
+++ b/pyicloud/services/notes/domain.py
@@ -1,3 +1,5 @@
+"""Domain models for note attachments and body content."""
+
 from __future__ import annotations
 
 from typing import List, Optional

--- a/pyicloud/services/notes/models/_ck_base.py
+++ b/pyicloud/services/notes/models/_ck_base.py
@@ -1,3 +1,5 @@
+"""Base models and configuration for CloudKit Notes models."""
+
 from __future__ import annotations
 
 import os

--- a/pyicloud/services/notes/models/constants.py
+++ b/pyicloud/services/notes/models/constants.py
@@ -1,3 +1,5 @@
+"""Constants and enums for Notes CloudKit records and queries."""
+
 from enum import Enum
 
 

--- a/pyicloud/services/notes/protobuf/__init__.py
+++ b/pyicloud/services/notes/protobuf/__init__.py
@@ -1,0 +1,1 @@
+"""Protocol buffer definitions for Notes service."""

--- a/pyicloud/services/notes/rendering/attachments.py
+++ b/pyicloud/services/notes/rendering/attachments.py
@@ -30,6 +30,8 @@ from .table_builder import render_table_from_mergeable
 
 @dataclass(frozen=True)
 class AttachmentContext:
+    """Immutable bundle of attachment metadata for rendering."""
+
     id: str
     uti: str
     title: Optional[str]
@@ -45,6 +47,7 @@ class AttachmentContext:
     pdf_object_height: Optional[int] = None
 
     def base_attrs(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        """Build base HTML attributes for attachment elements."""
         base = {
             "class": "attachment",
             "data-uti": self.uti,
@@ -105,13 +108,18 @@ def _link_attrs(
 
 
 class _Renderer:
+    """Base class for attachment type renderers."""
+
     def render(
         self, ctx: AttachmentContext, render_note_cb: Callable
     ) -> str:  # pragma: no cover - interface
+        """Render attachment to HTML fragment based on its type."""
         raise NotImplementedError
 
 
 class _DefaultRenderer(_Renderer):
+    """Fallback renderer for unknown attachment types."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         label = ctx.title or ctx.uti or "attachment"
         href = _safe_url(ctx.primary_url, allowed_schemes={"http", "https"})
@@ -122,6 +130,8 @@ class _DefaultRenderer(_Renderer):
 
 
 class _TableRenderer(_Renderer):
+    """Render table attachments with embedded table data."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         if ctx.mergeable_gz:
             html_tbl = render_table_from_mergeable(ctx.mergeable_gz, render_note_cb)
@@ -137,6 +147,8 @@ class _TableRenderer(_Renderer):
 
 
 class _UrlRenderer(_Renderer):
+    """Render URL/link attachments."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         title = ctx.title or ctx.uti or "link"
         href = _safe_url(
@@ -157,6 +169,8 @@ class _UrlRenderer(_Renderer):
 
 
 class _ImageRenderer(_Renderer):
+    """Render image attachments with responsive sizing."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         url = _safe_url(
             ctx.primary_url,
@@ -182,6 +196,8 @@ class _ImageRenderer(_Renderer):
 
 
 class _AudioRenderer(_Renderer):
+    """Render audio attachments with controls."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         url = _safe_url(ctx.primary_url, allowed_schemes={"http", "https"})
         if url:
@@ -193,6 +209,8 @@ class _AudioRenderer(_Renderer):
 
 
 class _VideoRenderer(_Renderer):
+    """Render video attachments with controls and responsive sizing."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         url = _safe_url(ctx.primary_url, allowed_schemes={"http", "https"})
         if url:
@@ -211,6 +229,8 @@ class _VideoRenderer(_Renderer):
 
 
 class _PdfRenderer(_Renderer):
+    """Render PDF attachments embedded or as links."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         title = ctx.title or "PDF"
         url = _safe_url(ctx.primary_url, allowed_schemes={"http", "https"})
@@ -252,6 +272,8 @@ class _PdfRenderer(_Renderer):
 
 
 class _VCardRenderer(_Renderer):
+    """Render contact/vCard attachments."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         title = ctx.title or "contact"
         href = _safe_url(ctx.primary_url, allowed_schemes={"http", "https"})
@@ -266,6 +288,8 @@ class _VCardRenderer(_Renderer):
 
 
 class _HashtagRenderer(_Renderer):
+    """Render hashtag inline attachments."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         # Avoid double prefix when AltText already includes '#'
         if ctx.title:
@@ -280,6 +304,8 @@ class _HashtagRenderer(_Renderer):
 
 
 class _CalculatorRenderer(_Renderer):
+    """Render calculator result inline attachments."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         # Render exactly what the server provides (AltTextEncrypted/TitleEncrypted/SummaryEncrypted),
         # without any additional normalization.
@@ -291,6 +317,8 @@ class _CalculatorRenderer(_Renderer):
 # side of an equation (e.g., "y = "). We mirror calculator's behavior and render
 # a semantic, non-clickable span with a distinct class.
 class _GraphExpressionRenderer(_Renderer):
+    """Render graph expression inline attachments from calculator."""
+
     def render(self, ctx: AttachmentContext, render_note_cb: Callable) -> str:
         label = ctx.title or ctx.uti or "expression"
         return h("span", **ctx.base_attrs({"class": "attachment calc-graph"}))(

--- a/pyicloud/services/notes/rendering/table_builder.py
+++ b/pyicloud/services/notes/rendering/table_builder.py
@@ -20,10 +20,14 @@ from ..protobuf import notes_pb2 as pb
 
 
 class TypeName(str, Enum):
+    """Enum for CloudKit table type names."""
+
     ICTABLE = "com.apple.notes.ICTable"
 
 
 class MapKey(str, Enum):
+    """Enum for CloudKit table structure keys."""
+
     CR_ROWS = "crRows"
     CR_COLUMNS = "crColumns"
     CELL_COLUMNS = "cellColumns"
@@ -31,6 +35,8 @@ class MapKey(str, Enum):
 
 @dataclass(frozen=True, slots=True)
 class TableSpec:
+    """Configuration for table structure parsing."""
+
     type_name: TypeName
     rows_key: MapKey
     cols_key: MapKey
@@ -50,17 +56,23 @@ MAX_TABLE_CELLS = 50_000
 
 @dataclass(slots=True)
 class Cell:
+    """Table cell containing rendered HTML content."""
+
     html: str = ""
 
 
 @dataclass(slots=True)
 class AxisState:
+    """Tracks row or column indices and total count."""
+
     indices: dict[int, int] = field(default_factory=dict)
     total: int = 0
 
 
 @dataclass(slots=True)
 class TableBuilder:
+    """Reconstructs and renders tables from MergeableData protobuf payloads."""
+
     key_items: List[str]
     type_items: List[str]
     uuid_items: List[bytes]
@@ -73,9 +85,11 @@ class TableBuilder:
     cells: List[List[Cell]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        """Initialize UUID index for efficient lookups."""
         self.uuid_index = {u: i for i, u in enumerate(self.uuid_items)}
 
     def _uuid_index_from_entry(self, entry: pb.MergeableDataObjectRow) -> Optional[int]:
+        """Extract UUID index from a mergeable data entry."""
         try:
             # custom_map.map_entry[0].value.unsigned_integer_value -> UUID VALUE
             val = entry.custom_map.map_entry[0].value.unsigned_integer_value
@@ -88,6 +102,7 @@ class TableBuilder:
             return None
 
     def _parse_axis(self, entry: pb.MergeableDataObjectRow, axis: AxisState) -> None:
+        """Parse row or column ordering from a mergeable data entry."""
         axis.total = 0
         axis.indices.clear()
         # 1) Array attachments reference UUID VALUES directly
@@ -116,12 +131,15 @@ class TableBuilder:
             pass
 
     def parse_rows(self, entry: pb.MergeableDataObjectRow) -> None:
+        """Parse and cache row ordering from table data."""
         self._parse_axis(entry, self.rows)
 
     def parse_cols(self, entry: pb.MergeableDataObjectRow) -> None:
+        """Parse and cache column ordering from table data."""
         self._parse_axis(entry, self.cols)
 
     def init_table_buffers(self) -> None:
+        """Initialize cell buffer grid with correct dimensions."""
         if (
             self.rows.total <= 0
             or self.cols.total <= 0
@@ -136,6 +154,7 @@ class TableBuilder:
         ]
 
     def parse_cell_columns(self, entry: pb.MergeableDataObjectRow) -> None:
+        """Extract and render cell contents into the cell buffer."""
         # entry.dictionary.element: key -> column dict
         for col in entry.dictionary.element:
             try:
@@ -173,6 +192,7 @@ class TableBuilder:
                     continue
 
     def render_html_table(self) -> Optional[str]:
+        """Generate HTML table from parsed cells and structure."""
         if not self.cells or self.rows.total == 0 or self.cols.total == 0:
             return None
         trs: List[object] = []
@@ -195,6 +215,7 @@ ALLOWED_TABLE_TYPES = {
 def render_table_from_mergeable(
     gz_bytes: bytes, render_note_cb: Callable[[pb.Note], str]
 ) -> Optional[str]:
+    """Parse gzipped MergeableData and render as HTML table, or None if invalid."""
     if not gz_bytes:
         return None
     try:

--- a/pyicloud/services/notes/service.py
+++ b/pyicloud/services/notes/service.py
@@ -59,10 +59,14 @@ _HAS_SUBFOLDER_FIELD = "HasSubfolder"
 
 
 class NoteNotFound(NotesError):
+    """Raised when a note cannot be found."""
+
     pass
 
 
 class NoteLockedError(NotesError):
+    """Raised when a note is password protected and cannot be accessed."""
+
     pass
 
 

--- a/pyicloud/services/reminders/models/domain.py
+++ b/pyicloud/services/reminders/models/domain.py
@@ -1,3 +1,5 @@
+"""Domain models for reminders and related data structures."""
+
 from datetime import datetime
 from enum import IntEnum
 from typing import Literal, Optional
@@ -8,6 +10,8 @@ from pyicloud.common.models import FrozenServiceModel, MutableServiceModel
 
 
 class Reminder(MutableServiceModel):
+    """A reminder in a reminders list with metadata and related IDs."""
+
     id: str
     list_id: str
     title: str
@@ -40,6 +44,8 @@ class ReminderChangeEvent(FrozenServiceModel):
 
 
 class RemindersList(MutableServiceModel):
+    """A collection of reminders with list metadata."""
+
     id: str
     title: str
     color: Optional[str] = None

--- a/pyicloud/services/reminders/models/results.py
+++ b/pyicloud/services/reminders/models/results.py
@@ -1,3 +1,5 @@
+"""Result models for reminders queries."""
+
 from __future__ import annotations
 
 from typing import Optional
@@ -16,11 +18,15 @@ from .domain import (
 
 
 class AlarmWithTrigger(FrozenServiceModel):
+    """Alarm paired with its optional location trigger."""
+
     alarm: Alarm
     trigger: Optional[LocationTrigger] = None
 
 
 class ListRemindersResult(FrozenServiceModel):
+    """Complete result of querying reminders including related alarms, attachments, and metadata."""
+
     reminders: list[Reminder]
     alarms: dict[str, Alarm]
     triggers: dict[str, LocationTrigger]

--- a/pyicloud/services/reminders/protobuf/typedef.py
+++ b/pyicloud/services/reminders/protobuf/typedef.py
@@ -1,3 +1,5 @@
+"""Protocol buffer type definitions for Reminders service."""
+
 TITLE_DOCUMENT_TYPEDEF = {
     "2": {
         "type": "message",

--- a/tests/services/__init__.py
+++ b/tests/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the reminders service."""

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -2893,10 +2893,14 @@ def test_notes_commands_report_reauthentication_and_unavailability() -> None:
     """Notes commands should wrap service reauth and service-unavailable failures."""
 
     class ReauthNotes:
+        """Mock Notes service that raises reauth exception."""
+
         def recents(self, *, limit: int = 50):
             raise context_module.PyiCloudFailedLoginException("No password set")
 
     class UnavailableNotes:
+        """Mock Notes service that raises unavailable exception."""
+
         def sync_cursor(self) -> str:
             raise context_module.PyiCloudServiceUnavailable("temporarily unavailable")
 
@@ -3913,10 +3917,14 @@ def test_reminders_commands_report_errors() -> None:
     )
 
     class ApiErrorReminders:
+        """Mock Reminders service that raises API error exception."""
+
         def sync_cursor(self) -> str:
             raise RemindersApiError("sync failed")
 
     class AuthErrorReminders:
+        """Mock Reminders service that raises auth error exception."""
+
         def sync_cursor(self) -> str:
             raise RemindersAuthError("token expired")
 
@@ -3937,10 +3945,14 @@ def test_reminders_commands_report_reauthentication_and_unavailability() -> None
     """Reminders commands should wrap service reauth and service-unavailable failures."""
 
     class ReauthReminders:
+        """Mock Reminders service that raises reauth exception."""
+
         def lists(self):
             raise context_module.PyiCloudFailedLoginException("No password set")
 
     class UnavailableReminders:
+        """Mock Reminders service that raises unavailable exception."""
+
         def sync_cursor(self) -> str:
             raise context_module.PyiCloudServiceUnavailable("temporarily unavailable")
 

--- a/tests/test_example_reminders_delta.py
+++ b/tests/test_example_reminders_delta.py
@@ -1,3 +1,5 @@
+"""Tests for the example reminders delta script."""
+
 import importlib.util
 import os
 import sys
@@ -26,6 +28,8 @@ def _load_example_reminders_delta():
 
 
 class TestExampleRemindersDelta(unittest.TestCase):
+    """Tests for the example reminders delta script."""
+
     def test_authenticate_uses_security_key_when_fido2_devices_are_available(self):
         module = _load_example_reminders_delta()
         api = MagicMock()

--- a/tests/test_hsa2_bridge.py
+++ b/tests/test_hsa2_bridge.py
@@ -38,6 +38,8 @@ from pyicloud.hsa2_bridge_prover import (
 
 
 class _FakeWebSocket:
+    """Mock WebSocket for testing."""
+
     def __init__(
         self,
         messages: list[bytes | Exception],
@@ -67,6 +69,8 @@ class _FakeWebSocket:
 
 
 class _FakePrivateKey:
+    """Mock private key for testing signature generation."""
+
     def sign(self, nonce: bytes, _algorithm: object) -> bytes:
         return b"signature-for-" + nonce[:4]
 

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -42,6 +42,8 @@ def load_invites_fixture(name: str) -> dict:
 
 
 class CodecsTest(unittest.TestCase):
+    """Tests for invite codecs."""
+
     def test_decode_json_bytes_round_trip(self):
         original = {"startSince1970": 1768435200000, "isAllDay": False}
         enc = encode_json_bytes(original)
@@ -93,6 +95,8 @@ class CodecsTest(unittest.TestCase):
 
 
 class DtoTest(unittest.TestCase):
+    """Tests for invites data transfer objects."""
+
     def test_rsvp_status_enum(self):
         self.assertEqual(int(RsvpStatus.NO_RESPONSE), 0)
         self.assertEqual(int(RsvpStatus.NOT_GOING), 1)
@@ -124,6 +128,8 @@ class DtoTest(unittest.TestCase):
 
 
 class InvitesServiceTest(unittest.TestCase):
+    """Tests for Invites service."""
+
     def setUp(self):
         self.service = InvitesService(
             service_root="https://example.com",
@@ -351,6 +357,8 @@ class InvitesServiceTest(unittest.TestCase):
 
 
 class OneTimeLinkGuestTest(unittest.TestCase):
+    """Tests for OneTimeLink guest models."""
+
     def test_default_collections_are_empty_tuples(self):
         otl = OneTimeLinkGuest(
             record_name="PARTICIPANT-X_otl",

--- a/tests/test_notes_cli.py
+++ b/tests/test_notes_cli.py
@@ -1,3 +1,5 @@
+"""Tests for the notes CLI example script."""
+
 import argparse
 import importlib.util
 import os
@@ -21,6 +23,8 @@ def _load_notes_cli():
 
 
 class TestNotesCli(unittest.TestCase):
+    """Tests for the notes CLI example script."""
+
     def _output_dir(self, name):
         path = os.path.join("/tmp/python-test-results", "notes-cli", name)
         os.makedirs(path, exist_ok=True)

--- a/tests/test_notes_rendering.py
+++ b/tests/test_notes_rendering.py
@@ -1,3 +1,5 @@
+"""Tests for notes rendering functionality."""
+
 import json
 import os
 import tempfile
@@ -34,11 +36,15 @@ with open(FIXTURE_PATH, "r", encoding="utf-8") as fixture_file:
 
 
 class _Field:
+    """Mock CloudKit field for testing."""
+
     def __init__(self, value):
         self.value = value
 
 
 class _Fields:
+    """Mock CloudKit fields collection for testing."""
+
     def __init__(self, values):
         self.values = values
 
@@ -52,6 +58,8 @@ class _Fields:
 
 
 class _Record:
+    """Mock CloudKit record for testing."""
+
     def __init__(self, record_name, fields):
         self.recordName = record_name
         self.recordType = "Attachment"
@@ -59,6 +67,8 @@ class _Record:
 
 
 class TestNoteRendering(unittest.TestCase):
+    """Tests for note rendering functionality."""
+
     def setUp(self):
         self.fixture = NOTE_FIXTURE
 
@@ -66,6 +76,8 @@ class TestNoteRendering(unittest.TestCase):
         # Helper to rebuild a pseudo-CKRecord from the JSON dict
         # We need to minimally satisfy what build_datasource expects (fields.get_value)
         class MockFields:
+            """Mock CloudKit fields for test record reconstruction."""
+
             def __init__(self, fields_dict):
                 self.d = fields_dict
 
@@ -257,15 +269,21 @@ class TestNoteRendering(unittest.TestCase):
 
     def test_render_table_from_mergeable_uses_later_valid_root_candidate(self):
         class _FakeValue:
+            """Mock value object for testing."""
+
             def __init__(self, object_index):
                 self.object_index = object_index
 
         class _FakeMapEntry:
+            """Mock map entry for testing table data."""
+
             def __init__(self, key, object_index):
                 self.key = key
                 self.value = _FakeValue(object_index)
 
         class _FakeRootEntry:
+            """Mock root entry for testing table structure."""
+
             def __init__(self, *map_entries):
                 self.custom_map = SimpleNamespace(type=0, map_entry=list(map_entries))
 
@@ -273,14 +291,20 @@ class TestNoteRendering(unittest.TestCase):
                 return field_name == "custom_map"
 
         class _AxisEntry:
+            """Mock axis entry for testing table dimensions."""
+
             def __init__(self, total):
                 self.total = total
 
         class _CellEntry:
+            """Mock cell entry for testing table content."""
+
             def __init__(self, html):
                 self.cell_html = html
 
         class _FakeProto:
+            """Mock protobuf for testing table rendering."""
+
             def __init__(self):
                 entries = [
                     _FakeRootEntry(
@@ -409,6 +433,8 @@ class TestNoteRendering(unittest.TestCase):
 
 
 class TestNoteExporter(unittest.TestCase):
+    """Tests for note export functionality."""
+
     def _note_record(self, record_name="note-1", title=b"Example Title"):
         return _Record(record_name, {"TitleEncrypted": title})
 


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add concise, purpose-focused docstrings to Python methods and classes:

- 13 module-level docstrings for missing descriptions
- 40+ class docstrings in CloudKit models (enums, field types, request/response models)
- 13 renderer class docstrings in notes rendering
- Table builder classes and methods docstrings
- Exception class docstrings (NoteNotFound, NoteLockedError)
- Data model docstrings (Reminder, RemindersList, AlarmWithTrigger, etc.)
- Test helper class docstrings across multiple test files

All docstrings follow one-line purpose format and are placed immediately after class/method definitions.

## Type of change

<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
