### PR TITLE
fix: trigger 2FA push notification after SRP authentication

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -630,6 +630,7 @@ class PyiCloudService:
         except PyiCloud2FARequiredException:
             LOGGER.debug("2FA required to complete authentication.")
             self._auth_data = self._get_mfa_auth_options()
+            self._request_2fa_code()
         except PyiCloudAPIResponseException as error:
             msg = "Invalid email/password combination."
             raise PyiCloudFailedLoginException(msg) from error
@@ -825,6 +826,42 @@ class PyiCloudService:
         self._clear_trusted_device_bridge_state()
         self._set_two_factor_delivery_state("unknown")
         return auth_options
+
+    def _request_2fa_code(self) -> None:
+        """Request a 2FA code delivery after SRP authentication requires MFA.
+
+        Apple does not automatically push a verification code for API-based
+        (non-browser) sessions after SRP. This method explicitly triggers the
+        push notification to trusted devices and falls back to SMS when available.
+        """
+        headers = self._get_auth_headers({"Accept": CONTENT_TYPE_JSON})
+
+        try:
+            self.session.get(
+                f"{self._auth_endpoint}/verify/trusteddevice",
+                headers=headers,
+            )
+            LOGGER.debug("Requested 2FA code via trusted device push")
+        except Exception:  # noqa: BLE001
+            LOGGER.debug("Could not request 2FA device push; will try SMS fallback")
+
+        trusted_phone_number = self._trusted_phone_number()
+        if trusted_phone_number is not None:
+            try:
+                self.session.put(
+                    f"{self._auth_endpoint}/verify/phone",
+                    json={
+                        "phoneNumber": trusted_phone_number.as_phone_number_payload(),
+                        "mode": "sms",
+                    },
+                    headers=headers,
+                )
+                LOGGER.debug(
+                    "Requested 2FA code via SMS (phone id %s)",
+                    trusted_phone_number.device_id,
+                )
+            except Exception:  # noqa: BLE001
+                LOGGER.debug("Could not request 2FA SMS code")
 
     def _set_two_factor_delivery_state(
         self, method: str, notice: Optional[str] = None

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2298,3 +2298,97 @@ def test_setup_cookie_directory_with_tilde_expansion(
         mock_umask.assert_called_with(0o700)
         mock_umask.assert_any_call(0o077)
         assert result == "/home/user/.pyicloud"
+
+
+def test_private_request_2fa_code_triggers_trusted_device_push(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """_request_2fa_code should GET /verify/trusteddevice to push a code to Apple devices."""
+
+    pyicloud_service._auth_data = {}
+    with patch("pyicloud.base.PyiCloudSession") as mock_session:
+        pyicloud_service._session = mock_session
+        mock_session.data = {"scnt": "test_scnt", "session_id": "test_session_id"}
+
+        pyicloud_service._request_2fa_code()
+
+        get_calls = mock_session.get.call_args_list
+        push_call = next(
+            (c for c in get_calls if "/verify/trusteddevice" in c.args[0]),
+            None,
+        )
+        assert push_call is not None, "Expected GET /verify/trusteddevice to be called"
+        assert push_call.kwargs["headers"]["Accept"] == "application/json"
+
+
+def test_private_request_2fa_code_sends_sms_when_phone_available(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """_request_2fa_code should also PUT /verify/phone when a trusted phone number is present."""
+
+    pyicloud_service._auth_data = {
+        "trustedPhoneNumber": {
+            "id": 1,
+        }
+    }
+    with patch("pyicloud.base.PyiCloudSession") as mock_session:
+        pyicloud_service._session = mock_session
+        mock_session.data = {"scnt": "test_scnt", "session_id": "test_session_id"}
+
+        pyicloud_service._request_2fa_code()
+
+        args = mock_session.put.call_args.args
+        kwargs = mock_session.put.call_args.kwargs
+        assert args[0] == f"{pyicloud_service._auth_endpoint}/verify/phone"
+        assert kwargs["json"] == {
+            "phoneNumber": {"id": 1},
+            "mode": "sms",
+        }
+
+
+def test_srp_authentication_calls_request_2fa_code_when_2fa_required(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """_srp_authentication should invoke _request_2fa_code after Apple signals 2FA is needed."""
+
+    import base64 as _base64
+
+    from pyicloud.exceptions import PyiCloud2FARequiredException as _2FAExc
+
+    init_response = MagicMock()
+    init_response.raise_for_status = MagicMock()
+    init_response.json.return_value = {
+        "salt": _base64.b64encode(b"\x00" * 32).decode(),
+        "b": _base64.b64encode(b"\x01" * 256).decode(),
+        "c": "session_context",
+        "iteration": 1000,
+        "protocol": "s2k",
+    }
+    authorize_response = MagicMock()
+    authorize_response.raise_for_status = MagicMock()
+
+    with (
+        patch("pyicloud.base.PyiCloudSession") as mock_session,
+        patch("pyicloud.base.srp.rfc5054_enable"),
+        patch("pyicloud.base.srp.no_username_in_x"),
+        patch("pyicloud.base.srp.User") as mock_srp_user_cls,
+        patch.object(pyicloud_service, "_get_mfa_auth_options", return_value={}),
+        patch.object(pyicloud_service, "_request_2fa_code") as mock_request_push,
+    ):
+        mock_usr = MagicMock()
+        mock_usr.start_authentication.return_value = ("uname", b"\x02" * 32)
+        mock_usr.process_challenge.return_value = b"\x03" * 32
+        mock_usr.H_AMK = b"\x04" * 32
+        mock_srp_user_cls.return_value = mock_usr
+
+        pyicloud_service._session = mock_session
+        mock_session.data = {}
+        mock_session.get.return_value = authorize_response
+        mock_session.post.side_effect = [
+            init_response,
+            _2FAExc("test@example.com", MagicMock()),
+        ]
+
+        pyicloud_service._srp_authentication()
+
+        mock_request_push.assert_called_once()


### PR DESCRIPTION
## Problem

After SRP `/signin/complete` raises `PyiCloud2FARequiredException`, pyicloud calls `_get_mfa_auth_options()` to retrieve auth options but never explicitly requests delivery of the verification code.

Apple does **not** automatically push a code to the user's trusted devices for API-based (non-browser) sessions. As a result, users waiting for the 6-digit code on their iPhone/Mac receive nothing — authentication stalls indefinitely.

This was observed with a real Apple ID password on an HSA2 account (the SRP path). The `GET /appleauth/auth` call fetches the challenge parameters, but without an explicit `GET /verify/trusteddevice` call, Apple's servers never trigger the device push.

## Fix

Add `_request_2fa_code()` which:
1. `GET /verify/trusteddevice` — explicitly triggers Apple to push the 6-digit code to all trusted devices (iPhone, Mac, etc.)
2. `PUT /verify/phone` (SMS fallback) — requests an SMS code if a trusted phone number is present in `_auth_data`

Call it automatically from `_srp_authentication()` immediately after `_get_mfa_auth_options()` populates `_auth_data`.

## Why not call the existing `request_2fa_code()`?

The public `request_2fa_code()` routes through the trusted-device bridge (WebSocket) or SMS. When neither is available (no bridge boot context, no SMS mode reported), it returns `False` and no code is delivered. The `GET /verify/trusteddevice` endpoint is the simpler, direct path to trigger the user-visible push notification independently of the bridge flow.

## Tests

Three new tests in `tests/test_base.py`:
- `test_private_request_2fa_code_triggers_trusted_device_push` — verifies the `GET /verify/trusteddevice` call is made
- `test_private_request_2fa_code_sends_sms_when_phone_available` — verifies SMS fallback via `PUT /verify/phone`
- `test_srp_authentication_calls_request_2fa_code_when_2fa_required` — integration: `_srp_authentication()` invokes `_request_2fa_code()` when Apple signals 2FA required

🤖 Generated with [Claude Code](https://claude.com/claude-code)