### PR TITLE
fix(reminders): declare CRDT lengths in UTF-16 code units, not codepoints

### DIFF
--- a/pyicloud/services/reminders/_protocol.py
+++ b/pyicloud/services/reminders/_protocol.py
@@ -157,7 +157,10 @@ def _decode_crdt_document(encrypted_value: str | bytes) -> str:
 
 def _encode_crdt_document(text: str) -> str:
     """Encode a string into an Apple versioned topotext CRDT document."""
-    text_length = len(text) if text else 0
+    # Apple measures topotext offsets in UTF-16 code units, not codepoints.
+    # An astral character (emoji, rarer CJK) is one codepoint but two units,
+    # so len() under-declares every length this document carries.
+    text_length = len(text.encode("utf-16-le")) // 2 if text else 0
     replica_uuid = bytes.fromhex("d46bcae41b8766c18d75efe35c9145c3")
     clock_max = 0xFFFF_FFFF
 

--- a/tests/services/test_reminders_cloudkit.py
+++ b/tests/services/test_reminders_cloudkit.py
@@ -8,6 +8,7 @@ realistic CKRecord JSON fixtures.
 import base64
 import json
 import logging
+import zlib
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -64,6 +65,10 @@ from pyicloud.services.reminders.models import (
     ReminderChangeEvent,
     RemindersList,
     URLAttachment,
+)
+from pyicloud.services.reminders.protobuf import (
+    reminders_pb2,
+    versioned_document_pb2,
 )
 from pyicloud.services.reminders.service import RemindersService
 
@@ -229,6 +234,34 @@ def test_protocol_crdt_round_trip():
 
     assert isinstance(encoded, str)
     assert decode_crdt_document(encoded) == "Round trip"
+
+
+def _decode_crdt_structure(encoded: str):
+    document = versioned_document_pb2.Document()  # type: ignore[attr-defined]
+    document.ParseFromString(zlib.decompress(base64.b64decode(encoded)))
+    value = reminders_pb2.String()  # type: ignore[attr-defined]
+    value.ParseFromString(document.version[0].data)
+    return value
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_length"),
+    [
+        ("Round trip", 10),
+        ("coffee ☕", 8),
+        ("rocket 🚀", 9),
+        ("🚀🚀", 4),
+    ],
+)
+def test_protocol_crdt_declares_utf16_lengths(text: str, expected_length: int):
+    value = _decode_crdt_structure(encode_crdt_document(text))
+
+    assert expected_length == len(text.encode("utf-16-le")) // 2
+    assert [s.length for s in value.substring if s.length] == [expected_length]
+    assert [a.length for a in value.attributeRun] == [expected_length]
+    assert [
+        replica.clock for clock in value.timestamp.clock for replica in clock.replicaClock
+    ] == [expected_length, 1]
 
 
 def test_protocol_resolution_token_map_structure():


### PR DESCRIPTION
Reminder titles containing emoji are written successfully and read back correctly by
`pyicloud`, but display as **blank** in the Reminders app on iOS and macOS. The reminder
itself exists — alarms fire, it can be completed, and `list_reminders()` returns the right
title — only the title text never draws.

## Mechanism

`_encode_crdt_document()` builds Apple's versioned topotext document, which declares the
length of the text in three places:

* `substring[i].length` — the content run
* `attributeRun[i].length` — the attribute run
* `timestamp.clock[0].replicaClock[0].clock` — the replica clock

All three are derived from one value:

```python
text_length = len(text) if text else 0
```

Apple measures topotext offsets in **UTF-16 code units**; `len()` counts **codepoints**.
For ASCII and for characters in the Basic Multilingual Plane the two agree, which is why
this has gone unnoticed. For an astral character — every emoji above U+FFFF, and some CJK
extension blocks — one codepoint is *two* UTF-16 units, so each one makes the document
declare a length shorter than the string it describes.

The document is then internally inconsistent, and the Reminders app declines to lay it out.
Nothing rejects it server-side, so the write succeeds and the error surfaces only on a
device.

## Why the existing round-trip test cannot catch it

`test_protocol_crdt_round_trip` passes on the current code even for astral input, because
`_decode_crdt_document()` reads `value.string` and ignores the length metadata entirely:

```
text='rocket 🚀'
  codepoints=8   utf16_units=9
  substring.length=[8]   attributeRun.length=[8]   replicaClock=[8, 1]
  decode(encode(text)) == text  ->  True      # round trip is clean
  document self-consistent      ->  False     # but the lengths disagree with the text
```

The encoder and decoder share the same blind spot, so they agree with each other while
disagreeing with Apple. The test added here is therefore **structural** — it inspects the
declared lengths rather than round-tripping — which is what makes it able to fail.

## Reproduction

```python
import base64, zlib
from pyicloud.services.reminders._protocol import _encode_crdt_document
from pyicloud.services.reminders.protobuf import reminders_pb2, versioned_document_pb2

text = "rocket \U0001f680"
document = versioned_document_pb2.Document()
document.ParseFromString(zlib.decompress(base64.b64decode(_encode_crdt_document(text))))
value = reminders_pb2.String()
value.ParseFromString(document.version[0].data)

print([s.length for s in value.substring if s.length])   # [8]
print(len(text.encode("utf-16-le")) // 2)                # 9
```

End to end: create a reminder titled `"rocket 🚀"`, then look at the list on an iPhone —
the row is present, and its title is empty.

## Fix

One expression. Because all three declared lengths derive from `text_length`, correcting it
at the source fixes the content run, the attribute run and the replica clock together:

```python
text_length = len(text.encode("utf-16-le")) // 2 if text else 0
```

## Test

`test_protocol_crdt_declares_utf16_lengths` checks all three declared lengths against the
string's UTF-16 length, parameterised over ASCII, a BMP emoji, one astral emoji, and two
astral emoji.

Verified as a genuine regression test rather than assumed to be one:

| case | UTF-16 units | before | after |
|---|---|---|---|
| `"Round trip"` | 10 | pass | pass |
| `"coffee ☕"` (BMP) | 8 | pass | pass |
| `"rocket 🚀"` (astral) | 9 | **fail** (declares 8) | pass |
| `"🚀🚀"` (two astral) | 4 | **fail** (declares 2) | pass |

The ASCII and BMP cases pass both before and after, so the change is confined to astral
input and does not shift any length that was already correct.

## Verified

The fix is running against live iCloud, and titles containing emoji now render on-device.
Checked methodically with a control string alongside 🥛 🎉 🔑 🚀 — the control was readable
in both cases, and all four emoji titles went from blank to correct.

Found while integrating against `pyicloud` 2.6.5; the patch is against `main`
(`_protocol.py:160`), where the code is identical.

Python 3.10+ per the project's `requires-python`; the fix uses only the standard library
and adds no dependency.
