### PR TITLE
feat(reminders): expose `deleted` on RemindersList

### DIFF
--- a/pyicloud/services/reminders/_mappers.py
+++ b/pyicloud/services/reminders/_mappers.py
@@ -151,6 +151,7 @@ class RemindersRecordMapper:
             badge_emblem=fields.get_value("BadgeEmblem"),
             sorting_style=fields.get_value("SortingStyle"),
             is_group=bool(fields.get_value("IsGroup")),
+            deleted=bool(fields.get_value("Deleted") or 0),
             reminder_ids=reminder_ids,
             record_change_tag=rec.recordChangeTag,
         )

--- a/pyicloud/services/reminders/_mappers.py
+++ b/pyicloud/services/reminders/_mappers.py
@@ -151,7 +151,7 @@ class RemindersRecordMapper:
             badge_emblem=fields.get_value("BadgeEmblem"),
             sorting_style=fields.get_value("SortingStyle"),
             is_group=bool(fields.get_value("IsGroup")),
-            deleted=bool(fields.get_value("Deleted") or 0),
+            deleted=bool(fields.get_value("Deleted")),
             reminder_ids=reminder_ids,
             record_change_tag=rec.recordChangeTag,
         )

--- a/pyicloud/services/reminders/models/domain.py
+++ b/pyicloud/services/reminders/models/domain.py
@@ -53,6 +53,7 @@ class RemindersList(MutableServiceModel):
     badge_emblem: str | None = None
     sorting_style: str | None = None
     is_group: bool = False
+    deleted: bool = False
     reminder_ids: list[str] = Field(default_factory=list)
     guid: str | None = None
     record_change_tag: str | None = None

--- a/tests/services/test_reminders_cloudkit.py
+++ b/tests/services/test_reminders_cloudkit.py
@@ -750,6 +750,21 @@ class TestRecordToList:
         assert lst.color == "#FF6600"
         assert lst.count == 16
         assert lst.is_group is False
+        assert lst.deleted is False
+
+    def test_deleted_list(self, service):
+        """A deleted list keeps its tombstone in the zone; expose the flag."""
+        rec = _ck_record(
+            "List",
+            "LIST-003",
+            {
+                "Name": {"type": "STRING", "value": "Old list"},
+                "Deleted": {"type": "INT64", "value": 1},
+            },
+        )
+        lst = service._record_to_list(rec)
+
+        assert lst.deleted is True
 
     def test_fixture_list_query_record(self, service: RemindersService) -> None:
         """Parsing a fixture List query record works."""

--- a/tests/services/test_reminders_cloudkit.py
+++ b/tests/services/test_reminders_cloudkit.py
@@ -752,7 +752,7 @@ class TestRecordToList:
         assert lst.is_group is False
         assert lst.deleted is False
 
-    def test_deleted_list(self, service):
+    def test_deleted_list(self, service: RemindersService) -> None:
         """A deleted list keeps its tombstone in the zone; expose the flag."""
         rec = _ck_record(
             "List",


### PR DESCRIPTION
## Problem

`Reminder` carries a `deleted` flag, but `RemindersList` does not — even though `lists()` yields a raw snapshot of **every** `List` record in the zone, including the tombstones left behind by deleted lists.

So a consumer cannot tell a live list from a deleted one. In practice the tombstones surface as permanently empty lists, and the only way to filter them today is to bypass the public API and read the raw records:

```python
service._reads._iter_zone_change_pages(desired_record_types=["List"])
```

which is exactly what a public model field should make unnecessary.

## Fix

Add `deleted: bool = False` to `RemindersList` and populate it in `record_to_list` from the same `Deleted` field that `record_to_reminder` already reads, so the two record types are consistent.

```python
is_group=bool(fields.get_value("IsGroup") or 0),
deleted=bool(fields.get_value("Deleted") or 0),
```

## Verification

On a live account, `lists()` returns 21 records of which several are tombstones — including three named `Family`, sharing a name with a live group and a live list. Filtering on `is_group` alone still leaves a duplicate, permanently empty entry; filtering on `deleted` as well resolves it to 16 real lists with no duplicate names.

## Tests

Adds `test_deleted_list` and asserts `deleted is False` in the existing basic-list test.

Full suite: **804 passed**.

Related: #317, #318 (same service, unrelated fix).