### PR TITLE
fix(calendar): parse Apple's date arrays into datetimes

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -239,6 +239,7 @@
     "topotext",
     "trusteddevice",
     "txnid",
+    "tzset",
     "udid",
     "ufffc",
     "unhexlify",

--- a/pyicloud/services/calendar.py
+++ b/pyicloud/services/calendar.py
@@ -596,6 +596,20 @@ class CalendarService(BaseService):
 
         return params
 
+    def _refresh_duration(self, obj: Any) -> None:
+        """Recompute an object's duration from its resolved start/end dates.
+
+        The object is constructed with default dates, so ``duration`` reflects
+        the defaults rather than the dates populated from the API payload.
+        """
+        start_date = getattr(obj, "start_date", None)
+        end_date = getattr(obj, "end_date", None)
+        if not hasattr(obj, "duration"):
+            return
+        if not isinstance(start_date, datetime) or not isinstance(end_date, datetime):
+            return
+        obj.duration = int((end_date.timestamp() - start_date.timestamp()) / 60)
+
     def obj_from_dict(self, obj: T, _dict: dict[str, Any]) -> T:
         """Creates an object from a dictionary with proper field validation."""
         if hasattr(obj, "__dataclass_fields__") and not isinstance(obj, type):
@@ -616,6 +630,8 @@ class CalendarService(BaseService):
                     setattr(
                         obj, field_name, _coerce(field_types.get(field_name), value)
                     )
+
+            self._refresh_duration(obj)
         else:
             for key, value in _dict.items():
                 setattr(obj, key, value)

--- a/pyicloud/services/calendar.py
+++ b/pyicloud/services/calendar.py
@@ -327,9 +327,9 @@ class EventObject:
             self.tz = get_localzone_name()
 
         # Calculate duration (should now always be positive due to validation)
-        self.duration = int(
-            (self.end_date.timestamp() - self.start_date.timestamp()) / 60
-        )
+        # Dates are naive wall-clock times, so subtract them directly rather
+        # than via timestamp(), which would fold in the process timezone/DST.
+        self.duration = int((self.end_date - self.start_date).total_seconds() / 60)
 
     def to_apple_event(self) -> AppleCalendarEvent:
         """
@@ -608,7 +608,7 @@ class CalendarService(BaseService):
             return
         if not isinstance(start_date, datetime) or not isinstance(end_date, datetime):
             return
-        obj.duration = int((end_date.timestamp() - start_date.timestamp()) / 60)
+        obj.duration = int((end_date - start_date).total_seconds() / 60)
 
     def obj_from_dict(self, obj: T, _dict: dict[str, Any]) -> T:
         """Creates an object from a dictionary with proper field validation."""

--- a/pyicloud/services/calendar.py
+++ b/pyicloud/services/calendar.py
@@ -179,7 +179,7 @@ def _coerce(annotation: Any, value: Any) -> Any:
     if isinstance(value, (list, tuple)) and len(value) >= 6:
         try:
             return AppleDateFormat.from_list(value).to_datetime()
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return value
     return value
 

--- a/pyicloud/services/calendar.py
+++ b/pyicloud/services/calendar.py
@@ -1,11 +1,12 @@
 """Calendar service."""
 
 from calendar import monthrange
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timedelta
 from secrets import randbelow
 import time
-from typing import Any, Literal, TypeVar, cast, overload
+from typing import Any, Literal, TypeVar, cast, get_args, overload
 from uuid import uuid4
 
 from requests import Response
@@ -119,6 +120,33 @@ class AppleDateFormat:
             minutes_from_midnight=minutes_calc,
         )
 
+    @classmethod
+    def from_list(cls, value: Sequence[int | str]) -> "AppleDateFormat":
+        """Build from Apple's 7-element date array."""
+        date_string, year, month, day, hour, minute = value[:6]
+        minutes_from_midnight = (
+            value[6] if len(value) > 6 else int(hour) * 60 + int(minute)
+        )
+        return cls(
+            date_string=str(date_string),
+            year=int(year),
+            month=int(month),
+            day=int(day),
+            hour=int(hour),
+            minute=int(minute),
+            minutes_from_midnight=int(minutes_from_midnight),
+        )
+
+    def to_datetime(self) -> datetime:
+        """Convert to a naive Python datetime.
+
+        Apple sends wall-clock time with the zone carried separately on the
+        event, so the result is intentionally naive.
+        """
+        return datetime(  # noqa: DTZ001
+            self.year, self.month, self.day, self.hour, self.minute
+        )
+
     def to_list(self) -> list[int | str]:
         """Convert to Apple's expected list format."""
         return [
@@ -130,6 +158,30 @@ class AppleDateFormat:
             self.minute,
             self.minutes_from_midnight,
         ]
+
+
+def _expects_datetime(annotation: Any) -> bool:
+    """Return whether a dataclass field is declared as holding a datetime."""
+    if annotation is datetime:
+        return True
+    return datetime in get_args(annotation)
+
+
+def _coerce(annotation: Any, value: Any) -> Any:
+    """Convert Apple's date arrays into datetimes for datetime fields.
+
+    The API returns dates as ``[YYYYMMDD, YYYY, MM, DD, HH, MM, minutes]``.
+    Fields declared as holding a ``datetime`` were previously populated with
+    that raw list, so the declared type did not match what callers received.
+    """
+    if not _expects_datetime(annotation) or isinstance(value, datetime):
+        return value
+    if isinstance(value, (list, tuple)) and len(value) >= 6:
+        try:
+            return AppleDateFormat.from_list(value).to_datetime()
+        except (TypeError, ValueError):
+            return value
+    return value
 
 
 @dataclass
@@ -548,6 +600,7 @@ class CalendarService(BaseService):
         """Creates an object from a dictionary with proper field validation."""
         if hasattr(obj, "__dataclass_fields__") and not isinstance(obj, type):
             valid_fields = {f.name for f in fields(cast(Any, obj))}
+            field_types = {f.name: f.type for f in fields(cast(Any, obj))}
 
             special_mappings = {
                 "pGuid": "pguid",
@@ -560,7 +613,9 @@ class CalendarService(BaseService):
                 )
 
                 if field_name in valid_fields:
-                    setattr(obj, field_name, value)
+                    setattr(
+                        obj, field_name, _coerce(field_types.get(field_name), value)
+                    )
         else:
             for key, value in _dict.items():
                 setattr(obj, key, value)

--- a/tests/services/test_calendar.py
+++ b/tests/services/test_calendar.py
@@ -645,3 +645,52 @@ def test_apple_alarm_dataclass() -> None:
     assert alarm.messageType == AlarmDefaults.MESSAGE_TYPE
     assert alarm.isLocationBased == AlarmDefaults.IS_LOCATION_BASED
     assert alarm.measurement.minutes == 15
+
+
+def test_apple_date_format_round_trip() -> None:
+    """Apple's date array converts to a datetime and back."""
+    raw = [20260909, 2026, 9, 9, 10, 0, 600]
+
+    parsed = AppleDateFormat.from_list(raw)
+
+    assert parsed.to_datetime() == datetime(2026, 9, 9, 10, 0)  # noqa: DTZ001
+    assert parsed.to_list() == ["20260909", 2026, 9, 9, 10, 0, 600]
+
+
+def test_event_dates_are_parsed_into_datetimes() -> None:
+    """Date fields are populated as datetimes, matching their annotations.
+
+    The API returns dates as a 7-element array, which used to be assigned to
+    the fields verbatim, so `EventObject.start_date` held a list despite being
+    declared as a `datetime`.
+    """
+    with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):
+        service = CalendarService("https://example.com", MagicMock(), {})
+        event: EventObject = service.obj_from_dict(
+            EventObject(pguid="cal"),
+            {
+                "startDate": [20260909, 2026, 9, 9, 10, 0, 600],
+                "endDate": [20260909, 2026, 9, 9, 11, 0, 660],
+                "localStartDate": [20260909, 2026, 9, 9, 10, 0, 600],
+                "title": "Lunch",
+            },
+        )
+
+    # Apple sends naive wall-clock time; the zone lives on the event.
+    assert event.start_date == datetime(2026, 9, 9, 10, 0)  # noqa: DTZ001
+    assert event.end_date == datetime(2026, 9, 9, 11, 0)  # noqa: DTZ001
+    assert event.local_start_date == datetime(2026, 9, 9, 10, 0)  # noqa: DTZ001
+    assert event.title == "Lunch"
+
+
+def test_event_dates_tolerate_unexpected_values() -> None:
+    """A malformed date is left alone rather than raising."""
+    with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):
+        service = CalendarService("https://example.com", MagicMock(), {})
+        event: EventObject = service.obj_from_dict(
+            EventObject(pguid="cal"),
+            {"startDate": ["nope"], "endDate": None},
+        )
+
+    assert event.start_date == ["nope"]
+    assert event.end_date is None

--- a/tests/services/test_calendar.py
+++ b/tests/services/test_calendar.py
@@ -2,6 +2,8 @@
 # pylint: disable=protected-access
 
 from datetime import datetime
+import os
+import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -712,6 +714,31 @@ def test_event_duration_left_alone_when_dates_unparsable() -> None:
     assert event.end_date == "also-nope"
     # Dates stayed unparsable, so the constructor-derived duration persists.
     assert event.duration == 60
+
+
+def test_event_duration_is_wall_clock_across_dst() -> None:
+    """_refresh_duration yields the wall-clock delta across a DST transition.
+
+    Dates are naive wall-clock times, so the elapsed minutes must not be
+    derived via ``datetime.timestamp()``, which folds in the process timezone
+    and reports a shorter duration across a DST transition.
+    """
+    os.environ["TZ"] = "America/New_York"
+    time.tzset()
+    try:
+        with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):
+            service = CalendarService("https://example.com", MagicMock(), {})
+        event = EventObject(pguid="cal")
+        # 01:30 -> 03:30 straddles the 2026-03-08 spring-forward (02:00 -> 03:00).
+        event.start_date = datetime(2026, 3, 8, 1, 30)
+        event.end_date = datetime(2026, 3, 8, 3, 30)
+        service._refresh_duration(event)
+        # The wall-clock delta is 120 minutes; a timestamp()-based calculation
+        # would instead report only 60 in the America/New_York timezone.
+        assert event.duration == 120
+    finally:
+        os.environ.pop("TZ", None)
+        time.tzset()
 
 
 def test_event_dates_tolerate_unexpected_values() -> None:

--- a/tests/services/test_calendar.py
+++ b/tests/services/test_calendar.py
@@ -683,6 +683,37 @@ def test_event_dates_are_parsed_into_datetimes() -> None:
     assert event.title == "Lunch"
 
 
+def test_event_duration_matches_resolved_dates() -> None:
+    """Duration reflects the parsed dates, not the constructor defaults."""
+    with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):
+        service = CalendarService("https://example.com", MagicMock(), {})
+        event: EventObject = service.obj_from_dict(
+            EventObject(pguid="cal"),
+            {
+                "startDate": [20260909, 2026, 9, 9, 9, 30, 570],
+                "endDate": [20260909, 2026, 9, 9, 12, 45, 765],
+            },
+        )
+
+    # 09:30 -> 12:45 is 195 minutes, not the constructor's default of 60.
+    assert event.duration == 195
+
+
+def test_event_duration_left_alone_when_dates_unparsable() -> None:
+    """Duration is not recomputed when dates could not be parsed."""
+    with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):
+        service = CalendarService("https://example.com", MagicMock(), {})
+        event: EventObject = service.obj_from_dict(
+            EventObject(pguid="cal"),
+            {"startDate": ["nope"], "endDate": "also-nope"},
+        )
+
+    assert event.start_date == ["nope"]
+    assert event.end_date == "also-nope"
+    # Dates stayed unparsable, so the constructor-derived duration persists.
+    assert event.duration == 60
+
+
 def test_event_dates_tolerate_unexpected_values() -> None:
     """A malformed date is left alone rather than raising."""
     with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):

--- a/tests/services/test_calendar.py
+++ b/tests/services/test_calendar.py
@@ -694,3 +694,25 @@ def test_event_dates_tolerate_unexpected_values() -> None:
 
     assert event.start_date == ["nope"]
     assert event.end_date is None
+
+
+def test_event_dates_tolerate_overflow_year() -> None:
+    """An absurdly large year raises OverflowError, which is tolerated."""
+    with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):
+        service = CalendarService("https://example.com", MagicMock(), {})
+        event: EventObject = service.obj_from_dict(
+            EventObject(pguid="cal"),
+            {
+                "startDate": [
+                    20260909,
+                    10**1000,
+                    9,
+                    9,
+                    10,
+                    0,
+                    600,
+                ]
+            },
+        )
+
+    assert event.start_date == [20260909, 10**1000, 9, 9, 10, 0, 600]


### PR DESCRIPTION
## Problem

`EventObject` annotates its date fields as holding a `datetime`:

```python
start_date: datetime = field(default_factory=datetime.today)
end_date: datetime = ...
local_start_date: Optional[datetime] = None
local_end_date: Optional[datetime] = None
```

But `obj_from_dict` assigns the API payload verbatim, so what callers actually get back is Apple's 7-element wire array:

```python
>>> event = service.get_events(as_objs=True)[0]
>>> event.start_date
[20260909, 2026, 9, 9, 10, 0, 600]
>>> event.start_date.date()
AttributeError: 'list' object has no attribute 'date'
```

Anything that trusts the annotation breaks, so every consumer ends up reimplementing the same parsing.

## Fix

`AppleDateFormat` already converts a `datetime` **into** that array via `from_datetime` / `to_list`, so this adds the mirror image — `from_list` and `to_datetime` — and applies it in `obj_from_dict` to fields whose declared type includes `datetime`.

The conversion is driven by the dataclass annotations rather than a hard-coded list of field names, so it stays correct if fields are added or renamed.

Deliberately conservative:

- values that are already a `datetime` pass straight through;
- anything unparseable is left exactly as-is rather than raising, so one malformed date cannot fail an entire fetch;
- `to_datetime()` returns a naive datetime, because Apple sends wall-clock time with the zone carried separately on the event's `tz` field. Converting here would guess at a timezone the caller is better placed to resolve.

## Verification

Against a live account, `get_events(..., as_objs=True)` over a three-week window:

```
21 events
  datetime  2026-09-09 10:00:00  ->  'Lezione Canto Fede (online)'
  datetime  2026-09-07 00:00:00  ->  'Labor Day'
  datetime  2026-09-01 09:30:00  ->  '🏋️ PT Federico in sala con Claudia'

start_date is datetime: 21/21
```

## Compatibility

This changes what those four fields contain, so it is technically a behaviour change for anyone who worked around the old value. That said, the previous value contradicted the declared type, and the write path (`request_data` / `dt_to_list`) already expects `datetime`, so round-tripping a fetched event was broken before this.

## Tests

Adds `test_apple_date_format_round_trip`, `test_event_dates_are_parsed_into_datetimes` and `test_event_dates_tolerate_unexpected_values`.

Full suite: **806 passed**. `ruff check` reports the same 73 pre-existing findings as `main` — this change adds none — and `ruff format --check` is clean.

Context: this came out of home-assistant/core#180735, where a reviewer rightly pointed out that the wire-format normalisation belongs in the library rather than in Home Assistant.