### PR TITLE
fix: handle Apple authenticationType key in 409 2FA responses

### DIFF
--- a/pyicloud/session.py
+++ b/pyicloud/session.py
@@ -359,11 +359,8 @@ class PyiCloudSession(requests.Session):
         if status_code == AppleAuthError.TWO_FACTOR_REQUIRED and self._is_json_response(
             response
         ):
-            data: dict[str, Any] = response.json()
-            if (
-                data.get("authType") == "hsa2"
-                or data.get("authenticationType") == "hsa2"
-            ):
+            auth_type: str | None = self._auth_type_from_hsa2_body(response)
+            if auth_type == "hsa2":
                 raise PyiCloud2FARequiredException(
                     apple_id=self.service.account_name,
                     response=response,
@@ -376,6 +373,26 @@ class PyiCloudSession(requests.Session):
             )
 
         self._raise_error(response, status_code, response.reason)
+
+    def _auth_type_from_hsa2_body(self, response: Response) -> str | None:
+        """Return the HSA2 authentication type from a challenge body, if any.
+
+        Apple uses ``authType`` on some endpoints and ``authenticationType`` on
+        the SMS securitycode challenge responses. JSON parsing is best-effort so
+        an empty, invalid, or non-object body falls through to the generic error
+        path rather than masking it.
+        """
+        try:
+            data = response.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        if data.get("authType") == "hsa2":
+            return "hsa2"
+        if data.get("authenticationType") == "hsa2":
+            return "hsa2"
+        return None
 
     def _decode_json_response(self, response: Response) -> None:
         """Decode JSON response."""

--- a/pyicloud/session.py
+++ b/pyicloud/session.py
@@ -356,18 +356,15 @@ class PyiCloudSession(requests.Session):
         response: Response,
     ) -> Response:
         """Handle request error."""
-        auth_type: str | None = response.json().get("authType") or response.json().get(
-            "authenticationType"
-        )
-        if (
-            status_code == AppleAuthError.TWO_FACTOR_REQUIRED
-            and self._is_json_response(response)
-            and auth_type == "hsa2"
+        if status_code == AppleAuthError.TWO_FACTOR_REQUIRED and self._is_json_response(
+            response
         ):
-            raise PyiCloud2FARequiredException(
-                apple_id=self.service.account_name,
-                response=response,
-            )
+            data: dict[str, Any] = response.json()
+            if (data.get("authType") or data.get("authenticationType")) == "hsa2":
+                raise PyiCloud2FARequiredException(
+                    apple_id=self.service.account_name,
+                    response=response,
+                )
 
         if status_code == AppleAuthError.FIND_MY_REAUTH_REQUIRED:
             raise PyiCloudAuthRequiredException(

--- a/pyicloud/session.py
+++ b/pyicloud/session.py
@@ -356,10 +356,13 @@ class PyiCloudSession(requests.Session):
         response: Response,
     ) -> Response:
         """Handle request error."""
+        auth_type: str | None = response.json().get("authType") or response.json().get(
+            "authenticationType"
+        )
         if (
             status_code == AppleAuthError.TWO_FACTOR_REQUIRED
             and self._is_json_response(response)
-            and (response.json().get("authType") == "hsa2")
+            and auth_type == "hsa2"
         ):
             raise PyiCloud2FARequiredException(
                 apple_id=self.service.account_name,

--- a/pyicloud/session.py
+++ b/pyicloud/session.py
@@ -360,7 +360,10 @@ class PyiCloudSession(requests.Session):
             response
         ):
             data: dict[str, Any] = response.json()
-            if (data.get("authType") or data.get("authenticationType")) == "hsa2":
+            if (
+                data.get("authType") == "hsa2"
+                or data.get("authenticationType") == "hsa2"
+            ):
                 raise PyiCloud2FARequiredException(
                     apple_id=self.service.account_name,
                     response=response,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1463,6 +1463,8 @@ def test_handle_request_error_two_factor_invalid_json_body(
     response = MagicMock()
     response.json.return_value = json_result
     response.headers = {"Content-Type": "application/json"}
+    response.reason = "Conflict"
+    response.text = ""
     with pytest.raises(PyiCloudAPIResponseException):
         pyicloud_session._handle_request_error(
             status_code=AppleAuthError.TWO_FACTOR_REQUIRED,
@@ -1477,6 +1479,8 @@ def test_handle_request_error_two_factor_json_decode_error(
     response = MagicMock()
     response.json.side_effect = ValueError("bad json")
     response.headers = {"Content-Type": "application/json"}
+    response.reason = "Conflict"
+    response.text = ""
     with pytest.raises(PyiCloudAPIResponseException):
         pyicloud_session._handle_request_error(
             status_code=AppleAuthError.TWO_FACTOR_REQUIRED,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,6 +17,7 @@ import requests
 from requests import HTTPError, Response
 
 from pyicloud import PyiCloudService
+from pyicloud.const import AppleAuthError
 from pyicloud.cookie_jar import PyiCloudCookieJar
 from pyicloud.exceptions import (
     PyiCloud2FARequiredException,
@@ -1414,6 +1415,24 @@ def test_raise_error_access_denied(pyicloud_session: PyiCloudSession) -> None:
     with pytest.raises(PyiCloudAPIResponseException):
         pyicloud_session._raise_error(
             code="ACCESS_DENIED", reason="ACCESS_DENIED", response=response
+        )
+
+
+@pytest.mark.parametrize(
+    "auth_key",
+    ["authType", "authenticationType"],
+)
+def test_handle_request_error_two_factor(
+    pyicloud_session: PyiCloudSession, auth_key: str
+) -> None:
+    """2FA is detected for both the authType and authenticationType response keys."""
+    response = MagicMock()
+    response.json.return_value = {auth_key: "hsa2"}
+    response.headers = {"Content-Type": "application/json"}
+    with pytest.raises(PyiCloud2FARequiredException):
+        pyicloud_session._handle_request_error(
+            status_code=AppleAuthError.TWO_FACTOR_REQUIRED,
+            response=response,
         )
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1444,6 +1444,46 @@ def test_handle_request_error_two_factor(
         )
 
 
+@pytest.mark.parametrize(
+    "json_result",
+    [
+        None,
+        "not a dict",
+        [],
+    ],
+)
+def test_handle_request_error_two_factor_invalid_json_body(
+    pyicloud_session: PyiCloudSession, json_result: object
+) -> None:
+    """A non-object/invalid 409 body falls through to the generic error path.
+
+    The HSA2 detector must not raise a JSON parsing or attribute error that
+    masks the intended PyiCloudAPIResponseException.
+    """
+    response = MagicMock()
+    response.json.return_value = json_result
+    response.headers = {"Content-Type": "application/json"}
+    with pytest.raises(PyiCloudAPIResponseException):
+        pyicloud_session._handle_request_error(
+            status_code=AppleAuthError.TWO_FACTOR_REQUIRED,
+            response=response,
+        )
+
+
+def test_handle_request_error_two_factor_json_decode_error(
+    pyicloud_session: PyiCloudSession,
+) -> None:
+    """A 409 whose JSON body fails to decode falls through to the generic path."""
+    response = MagicMock()
+    response.json.side_effect = ValueError("bad json")
+    response.headers = {"Content-Type": "application/json"}
+    with pytest.raises(PyiCloudAPIResponseException):
+        pyicloud_session._handle_request_error(
+            status_code=AppleAuthError.TWO_FACTOR_REQUIRED,
+            response=response,
+        )
+
+
 def test_request_pcs_for_service_icdrs_not_disabled(
     pyicloud_service: PyiCloudService, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1419,15 +1419,23 @@ def test_raise_error_access_denied(pyicloud_session: PyiCloudSession) -> None:
 
 
 @pytest.mark.parametrize(
-    "auth_key",
-    ["authType", "authenticationType"],
+    "payload",
+    [
+        {"authType": "hsa2"},
+        {"authenticationType": "hsa2"},
+        {"authType": "other", "authenticationType": "hsa2"},
+    ],
 )
 def test_handle_request_error_two_factor(
-    pyicloud_session: PyiCloudSession, auth_key: str
+    pyicloud_session: PyiCloudSession, payload: dict[str, str]
 ) -> None:
-    """2FA is detected for both the authType and authenticationType response keys."""
+    """2FA is detected via either response key.
+
+    Covers apple's alternate 'authenticationType' key, and the case where both
+    keys are present but 'authType' carries a non-hsa2 (truthy) value.
+    """
     response = MagicMock()
-    response.json.return_value = {auth_key: "hsa2"}
+    response.json.return_value = payload
     response.headers = {"Content-Type": "application/json"}
     with pytest.raises(PyiCloud2FARequiredException):
         pyicloud_session._handle_request_error(


### PR DESCRIPTION
## Proposed change

Fixes SMS 2FA validation failing with a generic `PyiCloudAPIResponseException: Authentication required for Account. (409)` instead of completing the 2FA flow.

`PyiCloudSession._handle_request_error()` only detected the HSA2 challenge by checking the `"authType"` key in the 409 response body. However, Apple's `/verify/phone/securitycode` endpoint (used by `_validate_sms_code()`) returns `"authenticationType": "hsa2"` instead. Because of this key mismatch, the 409 fell through to `_raise_error()` and abandoned the session despite Apple returning valid session/trust tokens.

This change makes the detector accept both key variants so the response correctly raises `PyiCloud2FARequiredException`, allowing `validate_2fa_code()` to proceed to `trust_session()`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #313
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.