### PR TITLE
feat: support minimal (paused) 2FA auth for Find My operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,31 @@ api = PyiCloudService(
 api.devices
 ```
 
+### Minimal authentication for Find My (`pause_2fa`)
+
+Some services (notably Find My) can be used without completing two-factor
+authentication (2FA). To allow a Find My-only workflow on an account that has
+2FA enabled, pass `pause_2fa=True` to the constructor. Authentication proceeds
+with an _untrusted_ session, so 2FA is not prompted and code delivery is
+deferred:
+
+```python
+from pyicloud import PyiCloudService
+
+api = PyiCloudService("jappleseed@apple.com", "password", pause_2fa=True)
+print(api.iphone.location)
+```
+
+**Security implications:** with `pause_2fa=True` the resulting session is **not
+trusted** by Apple, and only a limited set of 2FA-gated operations is
+available. It is intended for lightweight/headless usage (e.g. locating a
+device) where completing interactive 2FA each run is undesirable. Any operation
+that requires a trusted session — such as full 2FA-protected account access —
+will still need the normal 2FA flow (`request_2fa_code()` /
+`validate_2fa_code()`). In particular, a cached _untrusted_ session is only
+reused when the current call also enables `pause_2fa`; it is rejected on the
+default (trusted) flow to avoid silently bypassing 2FA.
+
 ## Command-Line Interface
 
 The `icloud` command line interface is organized around top-level

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -573,7 +573,7 @@ class PyiCloudService:
                     "until the 2FA challenge is completed."
                 )
                 return
-            self._authenticate_with_token()
+            self._authenticate_with_token(require_trust=not pause_2fa)
 
     def _srp_authentication(self, pause_2fa: bool = False) -> None:
         """SRP authentication."""

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -339,7 +339,7 @@ class PyiCloudService:
 
         return self._is_china_mainland
 
-    def authenticate(
+    def authenticate(  # noqa: S3776
         self,
         force_refresh: bool = False,
         service: str | None = None,
@@ -555,7 +555,9 @@ class PyiCloudService:
                 return
             self._authenticate_with_token()
 
-    def _srp_authentication(self, pause_2fa: bool = False) -> None:
+    def _srp_authentication(  # noqa: S3776
+        self, pause_2fa: bool = False
+    ) -> None:
         """SRP authentication."""
         if self._password_raw is None:
             raise PyiCloudFailedLoginException("No password set")
@@ -645,18 +647,13 @@ class PyiCloudService:
                 headers=self._get_auth_headers(),
             )
         except PyiCloud2FARequiredException:
-            if pause_2fa and self.session.data.get("session_token"):
-                LOGGER.debug(
-                    "2FA required but pause2FA is enabled; "
-                    "attempting session-token login."
-                )
-                try:
-                    self._authenticate_with_token(require_trust=False)
-                    return
-                except PyiCloudAPIResponseException:
-                    LOGGER.debug(
-                        "Paused session-token login failed; falling back to MFA flow."
-                    )
+            if (
+                pause_2fa
+                and self.session.data.get("session_token")
+                and self._login_with_paused_token()
+            ):
+                LOGGER.debug("Paused session-token login succeeded.")
+                return
             LOGGER.debug("2FA required to complete authentication.")
             self._requires_mfa = True
             self._auth_data = self._get_mfa_auth_options()
@@ -670,6 +667,20 @@ class PyiCloudService:
         except PyiCloudAPIResponseException as error:
             msg = "Invalid email/password combination."
             raise PyiCloudFailedLoginException(msg) from error
+
+    def _login_with_paused_token(self) -> bool:
+        """Attempt an untrusted session-token login for a paused 2FA session."""
+        if not self.session.data.get("session_token"):
+            return False
+        LOGGER.debug(
+            "2FA required but pause2FA is enabled; attempting session-token login."
+        )
+        try:
+            self._authenticate_with_token(require_trust=False)
+        except (PyiCloudAPIResponseException, PyiCloudFailedLoginException):
+            LOGGER.debug("Paused session-token login failed; falling back to MFA flow.")
+            return False
+        return True
 
     def _authenticate_with_token(self, require_trust: bool = True) -> None:
         """Authenticate using session token."""

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -373,21 +373,21 @@ class PyiCloudService:
     def _try_reuse_cached_session(self, force_refresh: bool, pause_2fa: bool) -> bool:
         """Validate and reuse a cached session token when it is allowed.
 
-        A cached session is only reused when it is trusted, or when the caller
-        explicitly opted into a paused (untrusted) 2FA session.
+        An intentionally untrusted (paused) session is only reused when the
+        caller explicitly opted into a paused 2FA flow; a trusted session is
+        always reusable so cookie/session persistence keeps working.
         """
-        if (
-            not self.session.data.get("session_token")
-            or force_refresh
-            or not (pause_2fa or self.is_trusted_session)
-        ):
+        if not self.session.data.get("session_token") or force_refresh:
             return False
         try:
             self.data = self._validate_token()
-            return True
         except PyiCloudAPIResponseException:
             LOGGER.debug("Invalid authentication token, will log in from scratch.")
             return False
+        if not self.is_trusted_session and not pause_2fa:
+            LOGGER.debug("Cached session is untrusted; requiring full authentication.")
+            return False
+        return True
 
     def _try_service_one_factor_login(self, service: str | None) -> bool:
         """Attempt a one-factor login for the requested service."""

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -354,7 +354,11 @@ class PyiCloudService:
             pause_2fa = self._pause_2fa
 
         login_successful = False
-        if self.session.data.get("session_token") and not force_refresh:
+        if (
+            self.session.data.get("session_token")
+            and not force_refresh
+            and (pause_2fa or self.is_trusted_session)
+        ):
             try:
                 self.data = self._validate_token()
                 login_successful = True

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -339,7 +339,7 @@ class PyiCloudService:
 
         return self._is_china_mainland
 
-    def authenticate(  # noqa: S3776
+    def authenticate(
         self,
         force_refresh: bool = False,
         service: str | None = None,
@@ -354,33 +354,11 @@ class PyiCloudService:
             pause_2fa = self._pause_2fa
 
         login_successful = False
-        if (
-            self.session.data.get("session_token")
-            and not force_refresh
-            and (pause_2fa or self.is_trusted_session)
-        ):
-            try:
-                self.data = self._validate_token()
-                login_successful = True
-            except PyiCloudAPIResponseException:
-                LOGGER.debug("Invalid authentication token, will log in from scratch.")
+        if self._try_reuse_cached_session(force_refresh, pause_2fa):
+            login_successful = True
 
-        if (
-            not login_successful
-            and service is not None
-            and self.data.get("apps")
-            and service in self.data["apps"]
-        ):
-            app: dict[str, Any] = self.data["apps"][service]
-            if "canLaunchWithOneFactor" in app and app["canLaunchWithOneFactor"]:
-                LOGGER.debug("Authenticating as %s for %s", self.account_name, service)
-                try:
-                    self._authenticate_with_credentials_service(service)
-                    login_successful = True
-                except PyiCloudFailedLoginException:
-                    LOGGER.debug(
-                        "Could not log into service. Attempting brand new login."
-                    )
+        if not login_successful and self._try_service_one_factor_login(service):
+            login_successful = True
 
         if not login_successful:
             try:
@@ -391,6 +369,44 @@ class PyiCloudService:
                 LOGGER.debug("2FA is required")
 
         self._update_state()
+
+    def _try_reuse_cached_session(self, force_refresh: bool, pause_2fa: bool) -> bool:
+        """Validate and reuse a cached session token when it is allowed.
+
+        A cached session is only reused when it is trusted, or when the caller
+        explicitly opted into a paused (untrusted) 2FA session.
+        """
+        if (
+            not self.session.data.get("session_token")
+            or force_refresh
+            or not (pause_2fa or self.is_trusted_session)
+        ):
+            return False
+        try:
+            self.data = self._validate_token()
+            return True
+        except PyiCloudAPIResponseException:
+            LOGGER.debug("Invalid authentication token, will log in from scratch.")
+            return False
+
+    def _try_service_one_factor_login(self, service: str | None) -> bool:
+        """Attempt a one-factor login for the requested service."""
+        if (
+            service is None
+            or not self.data.get("apps")
+            or service not in self.data["apps"]
+        ):
+            return False
+        app: dict[str, Any] = self.data["apps"][service]
+        if "canLaunchWithOneFactor" not in app or not app["canLaunchWithOneFactor"]:
+            return False
+        LOGGER.debug("Authenticating as %s for %s", self.account_name, service)
+        try:
+            self._authenticate_with_credentials_service(service)
+            return True
+        except PyiCloudFailedLoginException:
+            LOGGER.debug("Could not log into service. Attempting brand new login.")
+            return False
 
     def _handle_accept_terms(self, login_data: dict[str, Any]) -> None:
         """Handle accepting updated terms of service."""
@@ -559,9 +575,7 @@ class PyiCloudService:
                 return
             self._authenticate_with_token()
 
-    def _srp_authentication(  # noqa: S3776
-        self, pause_2fa: bool = False
-    ) -> None:
+    def _srp_authentication(self, pause_2fa: bool = False) -> None:
         """SRP authentication."""
         if self._password_raw is None:
             raise PyiCloudFailedLoginException("No password set")

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -257,6 +257,7 @@ class PyiCloudService:
         *,
         authenticate: bool = True,
         cloudkit_validation_extra: CloudKitExtraMode | None = None,
+        pause_2fa: bool = False,
     ) -> None:
         """Initialize a service session for one Apple ID account."""
         self._is_china_mainland: bool = (
@@ -327,9 +328,10 @@ class PyiCloudService:
 
         self._requires_mfa: bool = False
         self._two_factor_code_requested: bool = False
+        self._pause_2fa: bool = pause_2fa
 
         if authenticate:
-            self.authenticate()
+            self.authenticate(pause_2fa=pause_2fa)
 
     @property
     def is_china_mainland(self) -> bool:
@@ -338,12 +340,18 @@ class PyiCloudService:
         return self._is_china_mainland
 
     def authenticate(
-        self, force_refresh: bool = False, service: str | None = None
+        self,
+        force_refresh: bool = False,
+        service: str | None = None,
+        pause_2fa: bool | None = None,
     ) -> None:
         """
         Handles authentication, and persists cookies so that
         subsequent logins will not cause additional e-mails from Apple.
         """
+
+        if pause_2fa is None:
+            pause_2fa = self._pause_2fa
 
         login_successful = False
         if self.session.data.get("session_token") and not force_refresh:
@@ -372,7 +380,7 @@ class PyiCloudService:
 
         if not login_successful:
             try:
-                self._authenticate()
+                self._authenticate(pause_2fa=pause_2fa)
                 LOGGER.debug("Authentication completed successfully")
             except PyiCloud2FARequiredException:
                 self._requires_mfa = True
@@ -531,15 +539,15 @@ class PyiCloudService:
             "local_session_cleared": local_session_cleared,
         }
 
-    def _authenticate(self) -> None:
+    def _authenticate(self, pause_2fa: bool = False) -> None:
         """Authenticate with either the cached session token or fresh credentials."""
         LOGGER.debug("Authenticating as %s", self.account_name)
 
         try:
             self._authenticate_with_token()
         except (PyiCloudFailedLoginException, PyiCloud2FARequiredException):
-            self._srp_authentication()
-            if self._requires_mfa:
+            self._srp_authentication(pause_2fa=pause_2fa)
+            if self._requires_mfa or (pause_2fa and self.data):
                 LOGGER.debug(
                     "MFA is required; session-token authentication is deferred "
                     "until the 2FA challenge is completed."
@@ -547,7 +555,7 @@ class PyiCloudService:
                 return
             self._authenticate_with_token()
 
-    def _srp_authentication(self) -> None:
+    def _srp_authentication(self, pause_2fa: bool = False) -> None:
         """SRP authentication."""
         if self._password_raw is None:
             raise PyiCloudFailedLoginException("No password set")
@@ -624,6 +632,8 @@ class PyiCloudService:
             }
         if self.session.data.get("trust_token"):
             data["trustTokens"] = [self.session.data.get("trust_token")]
+        if pause_2fa:
+            data["pause2FA"] = True
 
         try:
             self.session.post(
@@ -635,6 +645,18 @@ class PyiCloudService:
                 headers=self._get_auth_headers(),
             )
         except PyiCloud2FARequiredException:
+            if pause_2fa and self.session.data.get("session_token"):
+                LOGGER.debug(
+                    "2FA required but pause2FA is enabled; "
+                    "attempting session-token login."
+                )
+                try:
+                    self._authenticate_with_token(require_trust=False)
+                    return
+                except PyiCloudAPIResponseException:
+                    LOGGER.debug(
+                        "Paused session-token login failed; falling back to MFA flow."
+                    )
             LOGGER.debug("2FA required to complete authentication.")
             self._requires_mfa = True
             self._auth_data = self._get_mfa_auth_options()
@@ -649,7 +671,7 @@ class PyiCloudService:
             msg = "Invalid email/password combination."
             raise PyiCloudFailedLoginException(msg) from error
 
-    def _authenticate_with_token(self) -> None:
+    def _authenticate_with_token(self, require_trust: bool = True) -> None:
         """Authenticate using session token."""
         if not self.session.data.get("session_token"):
             raise PyiCloudFailedLoginException("No session token available")
@@ -671,7 +693,7 @@ class PyiCloudService:
 
             self._handle_accept_terms(login_data)
 
-            if not self.is_trusted_session:
+            if require_trust and not self.is_trusted_session:
                 raise PyiCloud2FARequiredException(self.account_name, resp)
 
             self._auth_data = {}

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -566,17 +566,18 @@ class PyiCloudService:
         try:
             self._authenticate_with_token()
         except (PyiCloudFailedLoginException, PyiCloud2FARequiredException):
-            self._srp_authentication(pause_2fa=pause_2fa)
-            if self._requires_mfa or (pause_2fa and self.data):
+            paused_login_succeeded = self._srp_authentication(pause_2fa=pause_2fa)
+            if self._requires_mfa:
                 LOGGER.debug(
                     "MFA is required; session-token authentication is deferred "
                     "until the 2FA challenge is completed."
                 )
                 return
-            self._authenticate_with_token(require_trust=not pause_2fa)
+            if not pause_2fa or not paused_login_succeeded:
+                self._authenticate_with_token(require_trust=not pause_2fa)
 
-    def _srp_authentication(self, pause_2fa: bool = False) -> None:
-        """SRP authentication."""
+    def _srp_authentication(self, pause_2fa: bool = False) -> bool:
+        """SRP authentication; returns True when a paused token login succeeded."""
         if self._password_raw is None:
             raise PyiCloudFailedLoginException("No password set")
 
@@ -671,7 +672,7 @@ class PyiCloudService:
                 and self._login_with_paused_token()
             ):
                 LOGGER.debug("Paused session-token login succeeded.")
-                return
+                return True
             LOGGER.debug("2FA required to complete authentication.")
             self._requires_mfa = True
             self._auth_data = self._get_mfa_auth_options()
@@ -685,6 +686,7 @@ class PyiCloudService:
         except PyiCloudAPIResponseException as error:
             msg = "Invalid email/password combination."
             raise PyiCloudFailedLoginException(msg) from error
+        return False
 
     def _login_with_paused_token(self) -> bool:
         """Attempt an untrusted session-token login for a paused 2FA session."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2959,6 +2959,56 @@ def test_srp_authentication_pause_2fa_uses_token_when_409_returned(
         cast(Any, pyicloud_service.request_2fa_code).assert_not_called()
 
 
+def test_srp_authentication_pause_2fa_falls_back_when_token_login_fails(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """Paused SRP should fall back to MFA when the session-token login fails."""
+    init_response = MagicMock()
+    init_response.raise_for_status = MagicMock()
+    init_response.json.return_value = {
+        "salt": base64.b64encode(b"\x00" * 32).decode(),
+        "b": base64.b64encode(b"\x01" * 256).decode(),
+        "c": "session_context",
+        "iteration": 1000,
+        "protocol": "s2k",
+    }
+    authorize_response = MagicMock()
+    authorize_response.raise_for_status = MagicMock()
+
+    with (
+        patch("pyicloud.base.PyiCloudSession") as mock_session,
+        patch("pyicloud.base.srp.rfc5054_enable"),
+        patch("pyicloud.base.srp.no_username_in_x"),
+        patch("pyicloud.base.srp.User") as mock_srp_user_cls,
+        patch.object(
+            pyicloud_service,
+            "_authenticate_with_token",
+            side_effect=PyiCloudFailedLoginException("expired token"),
+        ) as mock_token_auth,
+        patch.object(pyicloud_service, "_get_mfa_auth_options", return_value={}),
+        patch.object(pyicloud_service, "request_2fa_code"),
+    ):
+        mock_usr = MagicMock()
+        mock_usr.start_authentication.return_value = ("uname", b"\x02" * 32)
+        mock_usr.process_challenge.return_value = b"\x03" * 32
+        mock_usr.H_AMK = b"\x04" * 32
+        mock_srp_user_cls.return_value = mock_usr
+
+        pyicloud_service._session = mock_session
+        mock_session.data = {"session_token": "paused-token"}
+        mock_session.get.return_value = authorize_response
+        mock_session.post.side_effect = [
+            init_response,
+            PyiCloud2FARequiredException("test@example.com", MagicMock()),
+        ]
+
+        pyicloud_service._srp_authentication(pause_2fa=True)
+
+        mock_token_auth.assert_called_once_with(require_trust=False)
+        assert pyicloud_service._requires_mfa is True
+        cast(Any, pyicloud_service.request_2fa_code).assert_called_once()
+
+
 def test_srp_authentication_pause_2fa_falls_back_to_mfa_without_token(
     pyicloud_service: PyiCloudService,
 ) -> None:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3091,7 +3091,9 @@ def test_authenticate_rejects_cached_untrusted_session_without_pause_2fa(
 
     with (
         patch.object(
-            pyicloud_service, "_validate_token", return_value={}
+            pyicloud_service,
+            "_validate_token",
+            return_value={"hsaTrustedBrowser": False},
         ) as mock_validate_token,
         patch.object(
             pyicloud_service,
@@ -3100,7 +3102,7 @@ def test_authenticate_rejects_cached_untrusted_session_without_pause_2fa(
     ):
         pyicloud_service.authenticate()
 
-        mock_validate_token.assert_not_called()
+        mock_validate_token.assert_called_once()
         mock_authenticate.assert_called_once_with(pause_2fa=False)
 
 
@@ -3113,7 +3115,9 @@ def test_authenticate_reuses_cached_untrusted_session_with_pause_2fa(
 
     with (
         patch.object(
-            pyicloud_service, "_validate_token", return_value={}
+            pyicloud_service,
+            "_validate_token",
+            return_value={"hsaTrustedBrowser": False},
         ) as mock_validate_token,
         patch.object(
             pyicloud_service,
@@ -3132,11 +3136,12 @@ def test_authenticate_reuses_cached_trusted_session_without_pause_2fa(
     """A cached trusted session is still reused with the default flow."""
     pyicloud_service._session = MagicMock()
     pyicloud_service._session.data = {"session_token": "valid-token"}
-    pyicloud_service.data = {"hsaTrustedBrowser": True}
 
     with (
         patch.object(
-            pyicloud_service, "_validate_token", return_value={}
+            pyicloud_service,
+            "_validate_token",
+            return_value={"hsaTrustedBrowser": True},
         ) as mock_validate_token,
         patch.object(
             pyicloud_service,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3080,3 +3080,70 @@ def test_authenticate_pause_2fa_skips_second_token_auth_after_paused_login(
         # Only the failed initial trusted login; no second re-login.
         assert mock_authenticate_with_token.call_count == 1
         assert pyicloud_service._requires_mfa is False
+
+
+def test_authenticate_rejects_cached_untrusted_session_without_pause_2fa(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """A cached untrusted (paused) session must not be reused without pause_2fa."""
+    pyicloud_service._session = MagicMock()
+    pyicloud_service._session.data = {"session_token": "paused-token"}
+
+    with (
+        patch.object(
+            pyicloud_service, "_validate_token", return_value={}
+        ) as mock_validate_token,
+        patch.object(
+            pyicloud_service,
+            "_authenticate",
+        ) as mock_authenticate,
+    ):
+        pyicloud_service.authenticate()
+
+        mock_validate_token.assert_not_called()
+        mock_authenticate.assert_called_once_with(pause_2fa=False)
+
+
+def test_authenticate_reuses_cached_untrusted_session_with_pause_2fa(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """A cached untrusted (paused) session is reused when pause_2fa is enabled."""
+    pyicloud_service._session = MagicMock()
+    pyicloud_service._session.data = {"session_token": "paused-token"}
+
+    with (
+        patch.object(
+            pyicloud_service, "_validate_token", return_value={}
+        ) as mock_validate_token,
+        patch.object(
+            pyicloud_service,
+            "_authenticate",
+        ) as mock_authenticate,
+    ):
+        pyicloud_service.authenticate(pause_2fa=True)
+
+        mock_validate_token.assert_called_once()
+        mock_authenticate.assert_not_called()
+
+
+def test_authenticate_reuses_cached_trusted_session_without_pause_2fa(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """A cached trusted session is still reused with the default flow."""
+    pyicloud_service._session = MagicMock()
+    pyicloud_service._session.data = {"session_token": "valid-token"}
+    pyicloud_service.data = {"hsaTrustedBrowser": True}
+
+    with (
+        patch.object(
+            pyicloud_service, "_validate_token", return_value={}
+        ) as mock_validate_token,
+        patch.object(
+            pyicloud_service,
+            "_authenticate",
+        ) as mock_authenticate,
+    ):
+        pyicloud_service.authenticate()
+
+        mock_validate_token.assert_called_once()
+        mock_authenticate.assert_not_called()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -39,7 +39,7 @@ from pyicloud.services.reminders import RemindersService
 from pyicloud.services.ubiquity import UbiquityService
 from pyicloud.session import PyiCloudSession
 from pyicloud.utils import b64_encode
-from tests.const import LOGIN_2FA
+from tests.const import LOGIN_2FA, LOGIN_WORKING
 
 
 def test_authenticate_with_force_refresh(
@@ -2683,7 +2683,8 @@ def test_authenticate_skips_token_auth_after_srp_2fa_required(
 ) -> None:
     """_authenticate avoids re-trying token auth once SRP reports MFA pending."""
 
-    def _mark_mfa_required() -> None:
+    def _mark_mfa_required(pause_2fa: bool = False) -> None:
+        del pause_2fa
         pyicloud_service._requires_mfa = True
         pyicloud_service._auth_data = {
             "phoneNumberVerification": {
@@ -2750,3 +2751,282 @@ def test_request_2fa_code_is_idempotent_for_srp_auto_request(
 
     pyicloud_service._trusted_device_bridge.start.assert_not_called()
     mock_session.put.assert_not_called()
+
+
+def test_constructor_passes_pause_2fa_to_authenticate() -> None:
+    """Constructor should forward pause_2fa to the authenticate call."""
+
+    with (
+        patch("pyicloud.PyiCloudService.authenticate") as mock_authenticate,
+        patch("pyicloud.PyiCloudService._setup_cookie_directory") as mock_setup_dir,
+        patch("builtins.open", new_callable=mock_open),
+    ):
+        mock_setup_dir.return_value = "/tmp/pyicloud/cookies"
+
+        service = PyiCloudService(
+            "test@example.com",
+            secrets.token_hex(32),
+            pause_2fa=True,
+        )
+
+        mock_authenticate.assert_called_once_with(pause_2fa=True)
+        assert service._pause_2fa is True
+
+
+def test_authenticate_with_token_require_trust_false_allows_untrusted_session(
+    pyicloud_service: PyiCloudService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """accountLogin should succeed for a paused (untrusted) session."""
+    login_payload = dict(LOGIN_WORKING)
+    login_payload["hsaTrustedBrowser"] = False
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = login_payload
+
+    monkeypatch.setattr(
+        pyicloud_service.session,
+        "post",
+        MagicMock(return_value=mock_resp),
+    )
+    pyicloud_service.session._data = {
+        "session_token": "paused-token",
+        "account_country": "USA",
+        "trust_token": "",
+    }
+
+    pyicloud_service._authenticate_with_token(require_trust=False)
+
+    assert pyicloud_service.data["hsaTrustedBrowser"] is False
+    assert pyicloud_service.requires_2fa is True
+    assert pyicloud_service._requires_mfa is False
+
+
+def test_authenticate_with_token_require_trust_true_raises_for_paused_session(
+    pyicloud_service: PyiCloudService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """accountLogin with require_trust=True should raise for a paused session."""
+    login_payload = dict(LOGIN_WORKING)
+    login_payload["hsaTrustedBrowser"] = False
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = login_payload
+
+    monkeypatch.setattr(
+        pyicloud_service.session,
+        "post",
+        MagicMock(return_value=mock_resp),
+    )
+    pyicloud_service.session._data = {
+        "session_token": "paused-token",
+        "account_country": "USA",
+        "trust_token": "",
+    }
+
+    with pytest.raises(PyiCloud2FARequiredException):
+        pyicloud_service._authenticate_with_token(require_trust=True)
+
+
+def test_srp_authentication_pause_2fa_includes_pause2fa_flag(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """SRP should send pause2FA=True when pause_2fa is enabled."""
+    init_response = MagicMock()
+    init_response.raise_for_status = MagicMock()
+    init_response.json.return_value = {
+        "salt": base64.b64encode(b"\x00" * 32).decode(),
+        "b": base64.b64encode(b"\x01" * 256).decode(),
+        "c": "session_context",
+        "iteration": 1000,
+        "protocol": "s2k",
+    }
+    authorize_response = MagicMock()
+    authorize_response.raise_for_status = MagicMock()
+    complete_response = MagicMock()
+
+    with (
+        patch("pyicloud.base.PyiCloudSession") as mock_session,
+        patch("pyicloud.base.srp.rfc5054_enable"),
+        patch("pyicloud.base.srp.no_username_in_x"),
+        patch("pyicloud.base.srp.User") as mock_srp_user_cls,
+    ):
+        mock_usr = MagicMock()
+        mock_usr.start_authentication.return_value = ("uname", b"\x02" * 32)
+        mock_usr.process_challenge.return_value = b"\x03" * 32
+        mock_usr.H_AMK = b"\x04" * 32
+        mock_srp_user_cls.return_value = mock_usr
+
+        pyicloud_service._session = mock_session
+        mock_session.data = {}
+        mock_session.get.return_value = authorize_response
+        mock_session.post.side_effect = [
+            init_response,
+            complete_response,
+        ]
+
+        pyicloud_service._srp_authentication(pause_2fa=True)
+
+        args, kwargs = mock_session.post.call_args
+        assert kwargs["json"]["pause2FA"] is True
+        assert args[0] == f"{pyicloud_service._auth_endpoint}/signin/complete"
+
+
+def test_srp_authentication_without_pause_2fa_omits_pause2fa_flag(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """SRP should omit pause2FA when pause_2fa is disabled."""
+    init_response = MagicMock()
+    init_response.raise_for_status = MagicMock()
+    init_response.json.return_value = {
+        "salt": base64.b64encode(b"\x00" * 32).decode(),
+        "b": base64.b64encode(b"\x01" * 256).decode(),
+        "c": "session_context",
+        "iteration": 1000,
+        "protocol": "s2k",
+    }
+    authorize_response = MagicMock()
+    authorize_response.raise_for_status = MagicMock()
+    complete_response = MagicMock()
+
+    with (
+        patch("pyicloud.base.PyiCloudSession") as mock_session,
+        patch("pyicloud.base.srp.rfc5054_enable"),
+        patch("pyicloud.base.srp.no_username_in_x"),
+        patch("pyicloud.base.srp.User") as mock_srp_user_cls,
+    ):
+        mock_usr = MagicMock()
+        mock_usr.start_authentication.return_value = ("uname", b"\x02" * 32)
+        mock_usr.process_challenge.return_value = b"\x03" * 32
+        mock_usr.H_AMK = b"\x04" * 32
+        mock_srp_user_cls.return_value = mock_usr
+
+        pyicloud_service._session = mock_session
+        mock_session.data = {}
+        mock_session.get.return_value = authorize_response
+        mock_session.post.side_effect = [
+            init_response,
+            complete_response,
+        ]
+
+        pyicloud_service._srp_authentication(pause_2fa=False)
+
+        _, kwargs = mock_session.post.call_args
+        assert "pause2FA" not in kwargs["json"]
+
+
+def test_srp_authentication_pause_2fa_uses_token_when_409_returned(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """Paused SRP should authenticate via token when Apple returns 2FA."""
+    init_response = MagicMock()
+    init_response.raise_for_status = MagicMock()
+    init_response.json.return_value = {
+        "salt": base64.b64encode(b"\x00" * 32).decode(),
+        "b": base64.b64encode(b"\x01" * 256).decode(),
+        "c": "session_context",
+        "iteration": 1000,
+        "protocol": "s2k",
+    }
+    authorize_response = MagicMock()
+    authorize_response.raise_for_status = MagicMock()
+
+    with (
+        patch("pyicloud.base.PyiCloudSession") as mock_session,
+        patch("pyicloud.base.srp.rfc5054_enable"),
+        patch("pyicloud.base.srp.no_username_in_x"),
+        patch("pyicloud.base.srp.User") as mock_srp_user_cls,
+        patch.object(pyicloud_service, "_authenticate_with_token") as mock_token_auth,
+        patch.object(pyicloud_service, "_get_mfa_auth_options"),
+        patch.object(pyicloud_service, "request_2fa_code"),
+    ):
+        mock_usr = MagicMock()
+        mock_usr.start_authentication.return_value = ("uname", b"\x02" * 32)
+        mock_usr.process_challenge.return_value = b"\x03" * 32
+        mock_usr.H_AMK = b"\x04" * 32
+        mock_srp_user_cls.return_value = mock_usr
+
+        pyicloud_service._session = mock_session
+        mock_session.data = {"session_token": "paused-token"}
+        mock_session.get.return_value = authorize_response
+        mock_session.post.side_effect = [
+            init_response,
+            PyiCloud2FARequiredException("test@example.com", MagicMock()),
+        ]
+
+        pyicloud_service._srp_authentication(pause_2fa=True)
+
+        mock_token_auth.assert_called_once_with(require_trust=False)
+        assert pyicloud_service._requires_mfa is False
+        cast(Any, pyicloud_service.request_2fa_code).assert_not_called()
+
+
+def test_srp_authentication_pause_2fa_falls_back_to_mfa_without_token(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """Paused SRP without a session token should fall back to MFA flow."""
+    init_response = MagicMock()
+    init_response.raise_for_status = MagicMock()
+    init_response.json.return_value = {
+        "salt": base64.b64encode(b"\x00" * 32).decode(),
+        "b": base64.b64encode(b"\x01" * 256).decode(),
+        "c": "session_context",
+        "iteration": 1000,
+        "protocol": "s2k",
+    }
+    authorize_response = MagicMock()
+    authorize_response.raise_for_status = MagicMock()
+
+    with (
+        patch("pyicloud.base.PyiCloudSession") as mock_session,
+        patch("pyicloud.base.srp.rfc5054_enable"),
+        patch("pyicloud.base.srp.no_username_in_x"),
+        patch("pyicloud.base.srp.User") as mock_srp_user_cls,
+        patch.object(pyicloud_service, "_get_mfa_auth_options", return_value={}),
+        patch.object(pyicloud_service, "request_2fa_code"),
+    ):
+        mock_usr = MagicMock()
+        mock_usr.start_authentication.return_value = ("uname", b"\x02" * 32)
+        mock_usr.process_challenge.return_value = b"\x03" * 32
+        mock_usr.H_AMK = b"\x04" * 32
+        mock_srp_user_cls.return_value = mock_usr
+
+        pyicloud_service._session = mock_session
+        mock_session.data = {}
+        mock_session.get.return_value = authorize_response
+        mock_session.post.side_effect = [
+            init_response,
+            PyiCloud2FARequiredException("test@example.com", MagicMock()),
+        ]
+
+        pyicloud_service._srp_authentication(pause_2fa=True)
+
+        assert pyicloud_service._requires_mfa is True
+        cast(Any, pyicloud_service.request_2fa_code).assert_called_once()
+
+
+def test_authenticate_pause_2fa_skips_second_token_auth_after_paused_login(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """_authenticate should not re-run trusted token login after a paused login."""
+
+    def _paused_login(pause_2fa: bool) -> None:
+        del pause_2fa
+        pyicloud_service.data = {"hsaTrustedBrowser": False, "webservices": {}}
+
+    with (
+        patch.object(
+            pyicloud_service,
+            "_authenticate_with_token",
+            side_effect=PyiCloudFailedLoginException("no session token"),
+        ) as mock_authenticate_with_token,
+        patch.object(
+            pyicloud_service,
+            "_srp_authentication",
+            side_effect=_paused_login,
+        ) as mock_srp_authentication,
+    ):
+        pyicloud_service._authenticate(pause_2fa=True)
+
+        mock_srp_authentication.assert_called_once_with(pause_2fa=True)
+        # Only the failed initial trusted login; no second re-login.
+        assert mock_authenticate_with_token.call_count == 1
+        assert pyicloud_service._requires_mfa is False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3058,9 +3058,10 @@ def test_authenticate_pause_2fa_skips_second_token_auth_after_paused_login(
 ) -> None:
     """_authenticate should not re-run trusted token login after a paused login."""
 
-    def _paused_login(pause_2fa: bool) -> None:
+    def _paused_login(pause_2fa: bool) -> bool:
         del pause_2fa
         pyicloud_service.data = {"hsaTrustedBrowser": False, "webservices": {}}
+        return True
 
     with (
         patch.object(
@@ -3086,7 +3087,9 @@ def test_authenticate_pause_2fa_success_path_uses_untrusted_token_auth(
     pyicloud_service: PyiCloudService,
 ) -> None:
     """SRP success with pause_2fa must not re-introduce a 2FA requirement."""
-    pyicloud_service.data = {}
+    # Non-empty (stale) data must not cause the follow-up token auth to be
+    # skipped; the gate should depend on whether a paused login actually ran.
+    pyicloud_service.data = {"hsaTrustedBrowser": False, "webservices": {}}
 
     calls: list[bool] = []
 
@@ -3104,7 +3107,7 @@ def test_authenticate_pause_2fa_success_path_uses_untrusted_token_auth(
         patch.object(
             pyicloud_service,
             "_srp_authentication",
-            return_value=None,
+            return_value=False,
         ),
     ):
         pyicloud_service._authenticate(pause_2fa=True)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3082,6 +3082,39 @@ def test_authenticate_pause_2fa_skips_second_token_auth_after_paused_login(
         assert pyicloud_service._requires_mfa is False
 
 
+def test_authenticate_pause_2fa_success_path_uses_untrusted_token_auth(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """SRP success with pause_2fa must not re-introduce a 2FA requirement."""
+    pyicloud_service.data = {}
+
+    calls: list[bool] = []
+
+    def _token_auth(require_trust: bool = True) -> None:
+        calls.append(require_trust)
+        if len(calls) == 1:
+            raise PyiCloudFailedLoginException("no session token")
+
+    with (
+        patch.object(
+            pyicloud_service,
+            "_authenticate_with_token",
+            side_effect=_token_auth,
+        ) as mock_authenticate_with_token,
+        patch.object(
+            pyicloud_service,
+            "_srp_authentication",
+            return_value=None,
+        ),
+    ):
+        pyicloud_service._authenticate(pause_2fa=True)
+
+        # Initial attempt failed; SRP completed; the follow-up token auth must
+        # accept the intentionally-untrusted paused session (require_trust=False).
+        assert mock_authenticate_with_token.call_count == 2
+        assert calls[1] is False
+
+
 def test_authenticate_rejects_cached_untrusted_session_without_pause_2fa(
     pyicloud_service: PyiCloudService,
 ) -> None:


### PR DESCRIPTION
## Breaking change

No breaking change. The new `pause_2fa` option is opt-in (defaults to `False`), preserving existing behavior.

## Proposed change

Adds a `pause_2fa` flag to `PyiCloudService` that skips the full MFA challenge for Find My iPhone operations (device listing, play sound). Apple's SRP `signin/complete` endpoint accepts a `pause2FA: true` parameter that returns a session token without completing 2FA — enough to authenticate FMIP operations like `play_sound()` locally.

## Type of change

- [x] New feature (which adds functionality to an existing service)

## Example of code:

```python
from pyicloud import PyiCloudService

api = PyiCloudService(username, password, pause_2fa=True)
device = next(iter(api.devices))
device.play_sound()
```

## Additional information

- This PR fixes or closes issue: fixes #298

Apple's web app (`https://www.icloud.com/find/`) allows "find device" and "play sound" with just username + password, no MFA. Previously pyicloud always ran the full HSA2/MFA flow, prompting unwanted sign-in requests on the user's device. With `pause_2fa=True`, the SRP flow sends `pause2FA: true`, uses the returned session token for a non-trusted `accountLogin`, and completes Find My operations without triggering the MFA prompt.

Note: with `pause_2fa=True` the session is intentionally not "trusted", so `api.requires_2fa` still reports `True` for operations that require a fully trusted session.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README