### PR TITLE
feat: make family device polling delay and max retries configurable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,11 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '18 16 * * 2'
+    - cron: "18 16 * * 2"
 
 jobs:
   analyze:
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: python
-          build-mode: none
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -56,46 +56,46 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
+      - name: Checkout repository
+        uses: actions/checkout@v7
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,36 +1,101 @@
-name: "CodeQL"
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
 
-# yamllint disable-line rule:truthy
 on:
   push:
+    branches: [ "main" ]
   pull_request:
+    branches: [ "main" ]
   schedule:
-    - cron: "30 18 * * 4"
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    - cron: '18 16 * * 2'
 
 jobs:
   analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      actions: read
-      contents: read
+      # required for all workflows
       security-events: write
 
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: python
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Checkout repository
+      uses: actions/checkout@v7
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
-        with:
-          languages: python
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
-        with:
-          category: "/language:python"
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,14 +14,14 @@ jobs:
     name: Run prek checks
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/yamllint.json"
           echo "::add-matcher::.github/workflows/matchers/check-json.json"
           echo "::add-matcher::.github/workflows/matchers/check-executables-have-shebangs.json"
           echo "::add-matcher::.github/workflows/matchers/codespell.json"
-
-      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,25 +1,46 @@
 name: Linting
 
-# yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
+
 jobs:
   prek:
     name: Run prek checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - name: Install Node dependencies
-        run: npm ci
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/yamllint.json"
           echo "::add-matcher::.github/workflows/matchers/check-json.json"
           echo "::add-matcher::.github/workflows/matchers/check-executables-have-shebangs.json"
           echo "::add-matcher::.github/workflows/matchers/codespell.json"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install Python dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements-dev.txt
+
+      - name: Install Prettier dependencies
+        run: npm ci
+
       - name: Run prek
-        uses: j178/prek-action@v2 # v1.1.0
-        env:
-          RUFF_OUTPUT_FORMAT: github
+        run: .venv/bin/prek run --all-files

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m venv .venv
           .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install -r requirements-dev.txt
+          .venv/bin/pip install -r requirements_all.txt
 
       - name: Install Prettier dependencies
         run: npm ci

--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -110,7 +110,7 @@ jobs:
             -Dsonar.sources=pyicloud
             -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=.coverage/coverage.xml
-            -Dsonar.python.version=3.14
+            -Dsonar.python.version=3.10,3.11,3.12,3.13,3.14
             -Dsonar.scm.revision=${{ steps.validate.outputs.head-sha }}
             -Dsonar.pullrequest.key=${{ steps.validate.outputs.pr-number }}
             -Dsonar.pullrequest.branch=${{ steps.validate.outputs.head-ref }}

--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -2,7 +2,7 @@ name: SonarQube
 
 on:
   workflow_run:
-    workflows: [Test]
+    workflows: [Tests]
     types: [completed]
 
 jobs:

--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -1,42 +1,32 @@
-name: SonarCloud.io
+name: SonarQube
 
-# yamllint disable-line rule:truthy
 on:
   workflow_run:
-    workflows: [Tests]
+    workflows: [Test]
     types: [completed]
-
-permissions:
-  actions: read
-  contents: read
-  pull-requests: read
 
 jobs:
   sonarqube:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      (github.event.workflow_run.event == 'pull_request' ||
-       (github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == 'main'))
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     env:
       SONAR_HOST_URL: https://sonarcloud.io
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.workflow_run.head_sha }}
-          allow-unsafe-pr-checkout: ${{ github.event.workflow_run.event == 'pull_request' }}
 
       - name: Require SonarQube credentials
-        if: ${{ secrets.SONAR_TOKEN == '' }}
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          echo "SONAR_TOKEN is not set; cannot run SonarQube analysis"
-          exit 1
+        if: env.SONAR_TOKEN == ''
+        run: exit 1
 
       - name: Download coverage report
         uses: actions/download-artifact@v8
@@ -62,9 +52,6 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_EVENT: ${{ github.event.workflow_run.event }}
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-          PR_HEAD_REF: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
-          PR_BASE_REF: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
         run: |
           set -euo pipefail
           [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid HEAD_SHA"; exit 1; }
@@ -72,71 +59,58 @@ jobs:
           if [[ "$RUN_EVENT" != "pull_request" ]]; then
             exit 0
           fi
-          PR_NUMBER="${PR_NUMBER:-}"
-          PR_HEAD_REF="${PR_HEAD_REF:-}"
-          PR_BASE_REF="${PR_BASE_REF:-}"
-          if [[ -z "$PR_NUMBER" || -z "$PR_HEAD_REF" || -z "$PR_BASE_REF" ]]; then
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [[ -z "$PR_NUMBER" ]]; then
+            # workflow_run.pull_requests is empty for fork PRs; resolve via the API.
             PR_FILE="$(mktemp)"
-            # Constrain by the head SHA so we don't rely on gh pr list's default
-            # 30-result page. gh --search matches PRs that contain the commit,
-            # which works whether HEAD_SHA is the PR tip or the merge SHA.
-            gh pr list --state open --search "$HEAD_SHA" --limit 100 \
-              --json number,headRefName,headRefOid,baseRefName > "$PR_FILE"
-            PR_MATCHES="$(jq -c '.' "$PR_FILE")"
-            PR_MATCH_COUNT="$(jq 'length' <<< "$PR_MATCHES")"
-            if [[ "$PR_MATCH_COUNT" -gt 1 ]]; then
-              echo "Ambiguous pull request metadata for $HEAD_SHA"; exit 1
-            fi
-            PR_MATCH="$(jq -c '.[0] // empty' <<< "$PR_MATCHES")"
+            gh pr list --state open --json number,headRefName,headRefOid,baseRefName > "$PR_FILE"
+            PR_MATCH="$(jq -c ".[] | select(.headRefOid == \"$HEAD_SHA\")" "$PR_FILE" | head -n 1)"
             if [[ -n "$PR_MATCH" ]]; then
-              PR_NUMBER="${PR_NUMBER:-$(jq -r '.number' <<< "$PR_MATCH")}"
-              PR_HEAD_REF="$(jq -r '.headRefName' <<< "$PR_MATCH")"
-              PR_BASE_REF="$(jq -r '.baseRefName' <<< "$PR_MATCH")"
+              PR_NUMBER="$(jq -r '.number' <<< "$PR_MATCH")"
+              HEAD_REF="$(jq -r '.headRefName' <<< "$PR_MATCH")"
+              BASE_REF="$(jq -r '.baseRefName' <<< "$PR_MATCH")"
             fi
+          else
+            HEAD_REF="${{ github.event.workflow_run.pull_requests[0].head.ref }}"
+            BASE_REF="${{ github.event.workflow_run.pull_requests[0].base.ref }}"
           fi
-          if [[ -z "$PR_NUMBER" || -z "$PR_HEAD_REF" || -z "$PR_BASE_REF" ]]; then
+          if [[ -z "$PR_NUMBER" || -z "$HEAD_REF" || -z "$BASE_REF" ]]; then
             echo "Could not resolve pull request metadata for $HEAD_SHA"; exit 1
           fi
           [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "Invalid PR number"; exit 1; }
-          [[ "$PR_HEAD_REF" =~ ^[a-zA-Z0-9][a-zA-Z0-9/@_.+-]*$ ]] || { echo "Invalid head branch"; exit 1; }
-          [[ "$PR_BASE_REF" =~ ^[a-zA-Z0-9][a-zA-Z0-9/@_.+-]*$ ]] || { echo "Invalid base branch"; exit 1; }
+          [[ "$HEAD_REF" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$ ]] || { echo "Invalid head branch"; exit 1; }
+          [[ "$BASE_REF" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$ ]] || { echo "Invalid base branch"; exit 1; }
           echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "head-ref=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
-          echo "base-ref=$PR_BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "head-ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
 
       - name: SonarQube Scan (branch)
-        if: >
-          github.event.workflow_run.event == 'push' &&
-          github.event.workflow_run.head_branch == 'main'
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: github.event.workflow_run.event == 'push'
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
           args: >-
             -Dsonar.projectKey=timlaing_pyicloud
             -Dsonar.organization=timlaing
             -Dsonar.projectName=pyicloud
-            -Dsonar.sources=./pyicloud
-            -Dsonar.tests=./tests
+            -Dsonar.sources=pyicloud
+            -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=.coverage/coverage.xml
-            -Dsonar.python.version=3.10,3.11,3.12,3.13,3.14
+            -Dsonar.python.version=3.14
             -Dsonar.scm.revision=${{ steps.validate.outputs.head-sha }}
             -Dsonar.qualitygate.wait=true
 
       - name: SonarQube Scan (pull request)
         if: github.event.workflow_run.event == 'pull_request'
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
           args: >-
             -Dsonar.projectKey=timlaing_pyicloud
             -Dsonar.organization=timlaing
             -Dsonar.projectName=pyicloud
-            -Dsonar.sources=./pyicloud
-            -Dsonar.tests=./tests
+            -Dsonar.sources=pyicloud
+            -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=.coverage/coverage.xml
-            -Dsonar.python.version=3.10,3.11,3.12,3.13,3.14
+            -Dsonar.python.version=3.14
             -Dsonar.scm.revision=${{ steps.validate.outputs.head-sha }}
             -Dsonar.pullrequest.key=${{ steps.validate.outputs.pr-number }}
             -Dsonar.pullrequest.branch=${{ steps.validate.outputs.head-ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,11 @@
 name: Tests
 
 # yamllint disable-line rule:truthy
-on: [workflow_dispatch, push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
@@ -19,40 +23,35 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+
       - name: Register Python problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/python.json"
       - name: Register pytest slow test problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/pytest-slow.json"
-      - name: Create Python virtual environment
+      - name: Install dependencies
         run: |
-          python -m venv venv
-          . venv/bin/activate
-          python --version
-          python3 -m pip install uv
-          uv pip install -U "pip>=25.2"
-          uv pip install -r requirements_all.txt
-      - name: Run pytest
-        timeout-minutes: 60
-        id: pytest-full
-        env:
-          PYTHONDONTWRITEBYTECODE: 1
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements_all.txt
+
+      - name: Run tests with coverage
         run: |
-          . venv/bin/activate
-          python --version
-          set -o pipefail
-          python3 -b -m pytest \
-            --cov="pyicloud" \
-            --cov-report=xml \
-            --junitxml=junit.xml -o junit_family=legacy
+          .venv/bin/python -m pytest \
+            --cov=pyicloud \
+            --cov-branch \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage.xml \
+            --timeout=30
 
       - name: Upload coverage report
         if: matrix.python-version == '3.14'

--- a/.yamllint
+++ b/.yamllint
@@ -1,61 +1,18 @@
-ignore: |
-  tests/
+extends: default
+
 rules:
-  braces:
-    level: error
-    min-spaces-inside: 0
-    max-spaces-inside: 1
-    min-spaces-inside-empty: -1
-    max-spaces-inside-empty: -1
-  brackets:
-    level: error
-    min-spaces-inside: 0
-    max-spaces-inside: 0
-    min-spaces-inside-empty: -1
-    max-spaces-inside-empty: -1
-  colons:
-    level: error
-    max-spaces-before: 0
-    max-spaces-after: 1
-  commas:
-    level: error
-    max-spaces-before: 0
-    min-spaces-after: 1
-    max-spaces-after: 1
-  comments:
-    level: error
-    require-starting-space: true
-    min-spaces-from-content: 1
-  comments-indentation:
-    level: error
-  document-end:
-    level: error
-    present: false
-  document-start:
-    level: error
-    present: false
-  empty-lines:
-    level: error
-    max: 1
-    max-start: 0
-    max-end: 1
-  hyphens:
-    level: error
-    max-spaces-after: 1
+  document-start: disable
+  new-line-at-end-of-file: disable
+  line-length: disable
   indentation:
-    level: error
     spaces: 2
     indent-sequences: true
     check-multi-line-strings: false
-  key-duplicates:
-    level: error
-  line-length: disable
-  new-line-at-end-of-file:
-    level: error
-  new-lines:
-    level: error
-    type: unix
-  trailing-spaces:
-    level: error
-  truthy:
-    level: error
+    ignore:
+      - cloud-config.yml
+  comments:
+    min-spaces-from-content: 1
+    ignore:
+      - cloud-config.yml
+
+ignore-from-file: .gitignore

--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ api = PyiCloudService(
 api.devices
 ```
 
+When `with_family=True`, Find My polls Apple's backend while family
+members' devices finish loading (`deviceFetchStatus` is `"LOADING"`). By
+default it polls every `0.5s` up to `5` times before giving up; both can be
+tuned via `family_poll_delay` and `family_poll_max_retries`:
+
+```python
+from pyicloud import PyiCloudService
+
+api = PyiCloudService(
+    "jappleseed@apple.com",
+    "password",
+    with_family=True,
+    family_poll_delay=1.0,  # seconds between polls (default: 0.5)
+    family_poll_max_retries=10,  # max polls (default: 5)
+)
+api.devices
+```
+
 ### Minimal authentication for Find My (`pause_2fa`)
 
 Some services (notably Find My) can be used without completing two-factor

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -254,6 +254,8 @@ class PyiCloudService:
         china_mainland: bool | None = None,
         accept_terms: bool = False,
         refresh_interval: float | None = None,
+        family_poll_delay: float = 0.5,
+        family_poll_max_retries: int = 5,
         *,
         authenticate: bool = True,
         cloudkit_validation_extra: CloudKitExtraMode | None = None,
@@ -287,6 +289,8 @@ class PyiCloudService:
         self.params: dict[str, Any] = {}
         self._client_id: str = client_id or str(uuid1()).lower()
         self._with_family: bool = with_family
+        self._family_poll_delay: float = family_poll_delay
+        self._family_poll_max_retries: int = family_poll_max_retries
         self._cloudkit_validation_extra = cloudkit_validation_extra
 
         _cookie_directory: str = self._setup_cookie_directory(cookie_directory)
@@ -1329,6 +1333,8 @@ class PyiCloudService:
                     params=self.params,
                     with_family=self._with_family,
                     refresh_interval=self._refresh_interval,
+                    family_poll_delay=self._family_poll_delay,
+                    family_poll_max_retries=self._family_poll_max_retries,
                 )
             except PyiCloudServiceNotActivatedException as error:
                 raise PyiCloudServiceUnavailable(

--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -20,7 +20,6 @@ from pyicloud.session import PyiCloudSession
 
 _FMIP_CLIENT_CONTEXT_TIMEZONE: str = "US/Pacific"
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-_MAX_REFRESH_RETRIES: int = 5
 
 
 def _monitor_thread(
@@ -55,6 +54,8 @@ class FindMyiPhoneServiceManager(BaseService):
         params: dict[str, Any],
         with_family: bool = False,
         refresh_interval: float | None = None,
+        family_poll_delay: float = 0.5,
+        family_poll_max_retries: int = 5,
     ) -> None:
         """Initialize the FindMyiPhoneServiceManager."""
         super().__init__(service_root, session, params)
@@ -62,6 +63,8 @@ class FindMyiPhoneServiceManager(BaseService):
         self._refresh_interval: float = (
             refresh_interval if refresh_interval is not None else 5.0 * 60.0
         )
+        self._family_poll_delay: float = family_poll_delay
+        self._family_poll_max_retries: int = family_poll_max_retries
 
         fmip_endpoint: str = f"{service_root}/fmipservice/client/web"
         self._fmip_init_url: str = f"{fmip_endpoint}/initClient"
@@ -112,14 +115,14 @@ class FindMyiPhoneServiceManager(BaseService):
         # Some members (e.g. Macs with location sharing disabled) remain permanently
         # LOADING and will never resolve. Track which members are LOADING between
         # retries and stop as soon as there is no progress, rather than always
-        # exhausting _MAX_REFRESH_RETRIES for stuck members.
+        # exhausting family_poll_max_retries for stuck members.
         retries: int = 0
         prev_loading_keys: set[str] = set()
         while (
             self._with_family
             and self._user_info
             and self._user_info.get("hasMembers", False)
-            and retries < _MAX_REFRESH_RETRIES
+            and retries < self._family_poll_max_retries
         ):
             loading_keys = {
                 k
@@ -136,7 +139,7 @@ class FindMyiPhoneServiceManager(BaseService):
                 break  # no change since last retry — give up on permanently
                 # stuck members
             prev_loading_keys = loading_keys
-            time.sleep(0.1)
+            time.sleep(self._family_poll_delay)
             self._refresh_client(locate=locate)
             retries += 1
 

--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -63,6 +63,10 @@ class FindMyiPhoneServiceManager(BaseService):
         self._refresh_interval: float = (
             refresh_interval if refresh_interval is not None else 5.0 * 60.0
         )
+        if isinstance(family_poll_delay, bool) or family_poll_delay < 0:
+            raise ValueError("family_poll_delay must be a non-negative number")
+        if isinstance(family_poll_max_retries, bool) or family_poll_max_retries < 0:
+            raise ValueError("family_poll_max_retries must be a non-negative integer")
         self._family_poll_delay: float = family_poll_delay
         self._family_poll_max_retries: int = family_poll_max_retries
 

--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -63,9 +63,17 @@ class FindMyiPhoneServiceManager(BaseService):
         self._refresh_interval: float = (
             refresh_interval if refresh_interval is not None else 5.0 * 60.0
         )
-        if isinstance(family_poll_delay, bool) or family_poll_delay < 0:
+        if isinstance(family_poll_delay, bool) or not isinstance(
+            family_poll_delay, (int, float)
+        ):
             raise ValueError("family_poll_delay must be a non-negative number")
-        if isinstance(family_poll_max_retries, bool) or family_poll_max_retries < 0:
+        if family_poll_delay < 0:
+            raise ValueError("family_poll_delay must be a non-negative number")
+        if isinstance(family_poll_max_retries, bool) or not isinstance(
+            family_poll_max_retries, int
+        ):
+            raise ValueError("family_poll_max_retries must be a non-negative integer")
+        if family_poll_max_retries < 0:
             raise ValueError("family_poll_max_retries must be a non-negative integer")
         self._family_poll_delay: float = family_poll_delay
         self._family_poll_max_retries: int = family_poll_max_retries

--- a/tests/services/test_findmyiphone.py
+++ b/tests/services/test_findmyiphone.py
@@ -796,18 +796,11 @@ def test_refresh_client_with_reauth_no_devices_raises(
         manager._refresh_client_with_reauth(locate=True)
 
 
-def test_family_poll_delay_is_used(
-    pyicloud_service_working: PyiCloudService,
-) -> None:
+def test_family_poll_delay_is_used() -> None:
     """Test _initialize_devices sleeps using the configured family_poll_delay."""
-    with patch(
-        "pyicloud.services.findmyiphone.FindMyiPhoneServiceManager."
-        "_refresh_client_with_reauth",
-        return_value=None,
-    ):
-        manager: FindMyiPhoneServiceManager = pyicloud_service_working.devices
+    with patch.object(FindMyiPhoneServiceManager, "_refresh_client_with_reauth"):
+        manager: FindMyiPhoneServiceManager = _make_manager(family_poll_delay=1.5)
     manager._with_family = True
-    manager._family_poll_delay = 1.5
 
     with (
         patch("time.sleep", return_value=None) as mock_sleep,
@@ -840,18 +833,11 @@ def test_family_poll_delay_is_used(
         assert mock_sleep.call_args_list == [call(1.5)]
 
 
-def test_family_poll_max_retries_is_respected(
-    pyicloud_service_working: PyiCloudService,
-) -> None:
+def test_family_poll_max_retries_is_respected() -> None:
     """Test _initialize_devices stops after the configured family_poll_max_retries."""
-    with patch(
-        "pyicloud.services.findmyiphone.FindMyiPhoneServiceManager."
-        "_refresh_client_with_reauth",
-        return_value=None,
-    ):
-        manager: FindMyiPhoneServiceManager = pyicloud_service_working.devices
+    with patch.object(FindMyiPhoneServiceManager, "_refresh_client_with_reauth"):
+        manager: FindMyiPhoneServiceManager = _make_manager(family_poll_max_retries=2)
     manager._with_family = True
-    manager._family_poll_max_retries = 2
 
     def member_info(loading: tuple[str, ...]) -> dict[str, object]:
         """Build a membersInfo payload with the given members still LOADING."""
@@ -906,14 +892,20 @@ def _make_manager(
 
 
 def test_family_poll_parameters_reject_invalid_values() -> None:
-    """Test family_poll parameters reject negative values and bools."""
+    """Test family_poll parameters reject negative, non-numeric, and bool values."""
     with patch.object(FindMyiPhoneServiceManager, "_refresh_client_with_reauth"):
         with pytest.raises(ValueError):
             _make_manager(family_poll_delay=-1)
         with pytest.raises(ValueError):
+            _make_manager(family_poll_delay=True)
+        with pytest.raises(ValueError):
+            _make_manager(family_poll_delay="0.5")
+        with pytest.raises(ValueError):
             _make_manager(family_poll_max_retries=-1)
         with pytest.raises(ValueError):
-            _make_manager(family_poll_delay=True)
+            _make_manager(family_poll_max_retries=True)
+        with pytest.raises(ValueError):
+            _make_manager(family_poll_max_retries=2.5)
 
 
 def test_monitor_thread_calls_func_at_interval() -> None:

--- a/tests/services/test_findmyiphone.py
+++ b/tests/services/test_findmyiphone.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access
 
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import pytest
@@ -793,6 +794,126 @@ def test_refresh_client_with_reauth_no_devices_raises(
         pytest.raises(PyiCloudNoDevicesException),
     ):
         manager._refresh_client_with_reauth(locate=True)
+
+
+def test_family_poll_delay_is_used(
+    pyicloud_service_working: PyiCloudService,
+) -> None:
+    """Test _initialize_devices sleeps using the configured family_poll_delay."""
+    with patch(
+        "pyicloud.services.findmyiphone.FindMyiPhoneServiceManager."
+        "_refresh_client_with_reauth",
+        return_value=None,
+    ):
+        manager: FindMyiPhoneServiceManager = pyicloud_service_working.devices
+    manager._with_family = True
+    manager._family_poll_delay = 1.5
+
+    with (
+        patch("time.sleep", return_value=None) as mock_sleep,
+        patch.object(manager, "_refresh_client"),
+        patch.object(manager, "_user_info") as mock_user_info,
+        patch.object(manager, "_devices", {"dummy_id": "dummy_device"}),
+    ):
+        mock_user_info.__getitem__.return_value = True
+        mock_user_info.get.side_effect = [
+            True,
+            {
+                "member1": {
+                    "firstName": "Member1",
+                    "lastName": "One",
+                    "appleId": "member1@example.com",
+                    "deviceFetchStatus": "LOADING",
+                },
+            },
+            True,
+            {
+                "member1": {
+                    "firstName": "Member1",
+                    "lastName": "One",
+                    "appleId": "member1@example.com",
+                    "deviceFetchStatus": "DONE",
+                },
+            },
+        ]
+        manager._refresh_client_with_reauth(locate=True)
+        assert mock_sleep.call_args_list == [call(1.5)]
+
+
+def test_family_poll_max_retries_is_respected(
+    pyicloud_service_working: PyiCloudService,
+) -> None:
+    """Test _initialize_devices stops after the configured family_poll_max_retries."""
+    with patch(
+        "pyicloud.services.findmyiphone.FindMyiPhoneServiceManager."
+        "_refresh_client_with_reauth",
+        return_value=None,
+    ):
+        manager: FindMyiPhoneServiceManager = pyicloud_service_working.devices
+    manager._with_family = True
+    manager._family_poll_max_retries = 2
+
+    def member_info(loading: tuple[str, ...]) -> dict[str, object]:
+        """Build a membersInfo payload with the given members still LOADING."""
+        return {
+            member: {
+                "firstName": member,
+                "lastName": "X",
+                "appleId": f"{member}@e.com",
+                "deviceFetchStatus": "LOADING" if member in loading else "DONE",
+            }
+            for member in ("m1", "m2", "m3")
+        }
+
+    # Each poll makes progress (one more member resolves), so the loop runs
+    # until family_poll_max_retries is reached rather than breaking on no-progress.
+    mock_user_info_get: list[object] = [
+        True,
+        member_info(("m1", "m2", "m3")),  # iteration 0
+        True,
+        member_info(("m2", "m3")),  # iteration 1
+        True,  # iteration 2: hasMembers True, but retries == max -> exit
+    ]
+
+    with (
+        patch("time.sleep", return_value=None),
+        patch.object(manager, "_refresh_client") as mock_refresh,
+        patch.object(manager, "_user_info") as mock_user_info,
+        patch.object(manager, "_devices", {"dummy_id": "dummy_device"}),
+    ):
+        mock_user_info.__getitem__.return_value = True
+        mock_user_info.get.side_effect = mock_user_info_get
+        manager._refresh_client_with_reauth(locate=True)
+        # 1 initial + _family_poll_max_retries loop iterations
+        assert mock_refresh.call_count == 1 + 2
+
+
+def _make_manager(
+    service_root: str = "root",
+    token_endpoint: str = "token",
+    session: MagicMock | None = None,
+    params: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> FindMyiPhoneServiceManager:
+    """Construct a FindMyiPhoneServiceManager without network calls."""
+    return FindMyiPhoneServiceManager(
+        service_root=service_root,
+        token_endpoint=token_endpoint,
+        session=session or MagicMock(),
+        params=params or {},
+        **kwargs,
+    )
+
+
+def test_family_poll_parameters_reject_invalid_values() -> None:
+    """Test family_poll parameters reject negative values and bools."""
+    with patch.object(FindMyiPhoneServiceManager, "_refresh_client_with_reauth"):
+        with pytest.raises(ValueError):
+            _make_manager(family_poll_delay=-1)
+        with pytest.raises(ValueError):
+            _make_manager(family_poll_max_retries=-1)
+        with pytest.raises(ValueError):
+            _make_manager(family_poll_delay=True)
 
 
 def test_monitor_thread_calls_func_at_interval() -> None:


### PR DESCRIPTION
## Proposed change

When `with_family=True`, `_initialize_devices()` polls `refreshClient` in a tight loop while family members' `deviceFetchStatus` is `"LOADING"`. Previously the delay between retries was hardcoded to `0.1s` and the max retries to `5` (a total window of only `0.5s`). For accounts with several family members, this often hits max retries before all devices finished loading.

This PR exposes both as configurable constructor parameters on `FindMyiPhoneServiceManager` (and plumbs them through `PyiCloudService`), defaulting to a higher `0.5s` delay:

```python
api = PyiCloudService(username, password, family_poll_delay=1.0, family_poll_max_retries=10)
```

The default poll delay is raised from `0.1s` to `0.5s` to give Apple's backend more time to finish loading family device data before the next poll, reducing the chance of hitting max retries before all devices are ready.

## Type of change

- [x] New feature (which adds functionality to an existing service)

## Example of code:

```python
api = PyiCloudService(
    username,
    password,
    with_family=True,
    family_poll_delay=1.0,          # optional, default 0.5
    family_poll_max_retries=10,     # optional, default 5
)
devices = api.devices
```

## Additional information

- This PR fixes or closes issue: fixes #205
- This PR is related to issue: #205

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README