### PR TITLE
fix: refresh webservices after token authentication

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -727,6 +727,16 @@ class PyiCloudService:
             if require_trust and not self.is_trusted_session:
                 raise PyiCloud2FARequiredException(self.account_name, resp)
 
+            # accountLogin returns a fresh webservices map, so derived state has
+            # to be refreshed here rather than only in authenticate(). Reached
+            # via trust_session() after 2FA, which otherwise leaves
+            # `_webservices` holding the reduced map from the pre-2FA login and
+            # makes get_webservice_url() raise for services that are present in
+            # `self.data`. Deliberately after the trust check, so the paths that
+            # raise keep deferring to authenticate()'s own _update_state() and
+            # this stays a no-op for them.
+            self._update_state()
+
             self._auth_data = {}
             self._hsa2_boot_context = None
             self._clear_trusted_device_bridge_state()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -965,6 +965,45 @@ def test_trust_session_success(pyicloud_service: PyiCloudService) -> None:
         assert pyicloud_service.trust_session()
 
 
+def test_trust_session_refreshes_webservices(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """Trusting a session must refresh the webservices map, not just the data.
+
+    Apple's pre-2FA accountLogin response carries a reduced webservices map.
+    trust_session() re-authenticates with the session token and receives the
+    complete one, so `_webservices` has to be refreshed alongside `data`;
+    otherwise get_webservice_url() raises for a service that is present in
+    `data["webservices"]`.
+    """
+
+    pyicloud_service.data = {
+        "webservices": {"ckdatabasews": {"url": "https://p51-ckdatabasews.example"}}
+    }
+    pyicloud_service._update_state()
+    assert "drivews" not in (pyicloud_service.webservices or {})
+
+    with patch("pyicloud.base.PyiCloudSession") as mock_session:
+        mock_session.data = {
+            "session_token": "test_session_token",
+            "account_country": "GBR",
+        }
+        mock_session.post.return_value.json.return_value = {
+            "dsInfo": {"dsid": "12345"},
+            "hsaTrustedBrowser": True,
+            "webservices": {
+                "ckdatabasews": {"url": "https://p51-ckdatabasews.example"},
+                "drivews": {"pcsRequired": True, "url": "https://p51-drivews.example"},
+            },
+        }
+        pyicloud_service._session = mock_session
+        assert pyicloud_service.trust_session()
+
+    assert (
+        pyicloud_service.get_webservice_url("drivews") == "https://p51-drivews.example"
+    )
+
+
 def test_trust_session_failure(pyicloud_service: PyiCloudService) -> None:
     """Test the trust_session method with a failed response."""
     with patch("pyicloud.base.PyiCloudSession") as mock_session:


### PR DESCRIPTION
## Proposed change

`_authenticate_with_token()` replaces `self.data` with a fresh `accountLogin` response but
never calls `_update_state()`, so `_webservices` keeps whatever it held before.
`_update_state()` is the only place `_webservices` is assigned, and it runs in just two
places — the end of `authenticate()` and after `_validate_token()` — neither of which covers
this path.

The visible effect is on the first login that completes 2FA. `validate_2fa_code()` calls
`trust_session()`, which re-authenticates with the session token and receives Apple's
complete webservices map. But `_webservices` still holds the reduced map from the pre-2FA
login, so a service present in `self.data["webservices"]` is missing from
`get_webservice_url()`, which raises `PyiCloudServiceNotActivatedException`. The next run,
reusing the now-trusted session, resolves the same service fine — because that path does go
through `authenticate()` and its `_update_state()` call.

This affects any service resolved on a first run after re-authenticating, and services
requiring PCS in particular, since those are the ones absent from the pre-2FA map.

The fix calls `_update_state()` once `self.data` is final. It is placed after the trust
check rather than before it, so the paths that raise `PyiCloud2FARequiredException` keep
deferring to `authenticate()`'s own `_update_state()` and are unaffected — including
`_login_with_paused_token()`. `_update_state()` only assigns `params["dsid"]` and
`_webservices` from `self.data`, so it is idempotent for the paths that already run it
afterwards.

### How it was found

While working on #331 (the Photos upload endpoint port), resolving the Photos upload
webservice raised on a fresh 2FA login even though `api.data["webservices"]` listed the
service. Reading the call graph explained the asymmetry: the two reads come from different
places, and only one of them gets refreshed.

The regression test reproduces it deterministically with no network and no Apple account —
it fails on `main` with exactly the error seen in the wild:

```
PyiCloudServiceNotActivatedException: Webservice not available: drivews
```

It uses `drivews` rather than the service that actually surfaced this, purely so the test
shares no vocabulary with #331 and the two branches stay independent.

### Verified against a live account

On a fresh login completing 2FA — the only state where the bug appears — all 33 advertised
services now resolve through `get_webservice_url()`, including every PCS-gated one, where
the Photos upload service previously did not. A trusted-session login beforehand and a
trusted reuse afterwards both behave as before, and `api.photos` constructs immediately
after 2FA.

That sweep also turned up something unrelated and pre-existing, which I have deliberately
left out of this PR: this account advertises `"schoolwork": {}`, an entry with no `url`.
`get_webservice_url()` passes its `is None` guard on that and then raises `KeyError: 'url'`
rather than the documented exception. It fails identically before and after this change.
Happy to send a separate PR adding a guard for entries without a `url`, if you would like
it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: surfaced while working on #316 / #331

Independent of #331: this branch is cut from `main` and touches only `pyicloud/base.py` and
`tests/test_base.py`. The two do touch the same files but not the same regions, and I
verified with a trial three-way merge that they combine cleanly, so they can be reviewed and
merged in either order.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
