### PR TITLE
feat: identify withdrawn endpoints instead of a generic response error

### DIFF
--- a/pyicloud/exceptions.py
+++ b/pyicloud/exceptions.py
@@ -4,6 +4,10 @@ from typing import Any
 
 from requests import Response
 
+# Apple answers a withdrawn endpoint with 410 rather than 404, which makes it an
+# unambiguous signal: the resource is permanently gone, not merely absent.
+HTTP_GONE: int = 410
+
 
 class PyiCloudException(Exception):
     """Generic iCloud exception."""
@@ -47,6 +51,37 @@ class PyiCloudAPIResponseException(PyiCloudException):
 
 class PyiCloudServiceNotActivatedException(PyiCloudAPIResponseException):
     """iCloud service not activated exception."""
+
+
+class PyiCloudEndpointGoneException(PyiCloudAPIResponseException):
+    """Raised when Apple reports an endpoint as permanently gone (HTTP 410).
+
+    Apple withdraws endpoints without notice, and has done so more than once.
+    A 410 means the endpoint this library calls no longer exists, so it signals
+    that pyicloud needs updating rather than that the caller's request,
+    credentials, or session were wrong.
+
+    Distinguishing it matters because the alternative is expensive: when the
+    Photos upload endpoint was withdrawn it surfaced as a generic response
+    error, and the reporter ruled out a stale session, an outdated client, a
+    missing PCS handshake, the wrong dsid, and the wrong partition before
+    concluding the endpoint itself had gone.
+
+    ``endpoint`` is a redacted host-and-path label safe to quote in a bug
+    report; the full URL is available on ``response`` when one was captured.
+    """
+
+    def __init__(self, endpoint: str, response: Response | None = None) -> None:
+        """Describe a withdrawn endpoint and point at the issue tracker."""
+        self.endpoint: str = endpoint
+        super().__init__(
+            f"Apple no longer serves {endpoint}. This endpoint appears to have "
+            "been withdrawn, which means pyicloud needs updating rather than "
+            "that your request was wrong. Please report it at "
+            "https://github.com/timlaing/pyicloud/issues and quote this endpoint",
+            HTTP_GONE,
+            response,
+        )
 
 
 # Login

--- a/pyicloud/exceptions.py
+++ b/pyicloud/exceptions.py
@@ -68,7 +68,8 @@ class PyiCloudEndpointGoneException(PyiCloudAPIResponseException):
     concluding the endpoint itself had gone.
 
     ``endpoint`` is a redacted host-and-path label safe to quote in a bug
-    report; the full URL is available on ``response`` when one was captured.
+    report; the full URL and the response body are available on ``response``
+    when one was captured.
     """
 
     def __init__(self, endpoint: str, response: Response | None = None) -> None:
@@ -80,8 +81,14 @@ class PyiCloudEndpointGoneException(PyiCloudAPIResponseException):
             "that your request was wrong. Please report it at "
             "https://github.com/timlaing/pyicloud/issues and quote this endpoint",
             HTTP_GONE,
-            response,
         )
+        # The response is deliberately withheld from the parent, which would
+        # append ``response.text`` to the message. This message exists to be
+        # pasted into a public issue, and Apple's error bodies can carry the
+        # dsid and session identifiers that ``endpoint`` was redacted to keep
+        # out of it. Attaching it here keeps the body reachable for debugging
+        # without folding it into quotable text.
+        self.response = response
 
 
 # Login

--- a/pyicloud/session.py
+++ b/pyicloud/session.py
@@ -6,6 +6,7 @@ import os
 from os import path
 from re import match
 from typing import TYPE_CHECKING, Any, NoReturn, cast
+from urllib.parse import urlsplit
 
 import requests
 from requests.models import Response
@@ -22,10 +23,12 @@ from pyicloud.const import (
 )
 from pyicloud.cookie_jar import PyiCloudCookieJar
 from pyicloud.exceptions import (
+    HTTP_GONE,
     PyiCloud2FARequiredException,
     PyiCloud2SARequiredException,
     PyiCloudAPIResponseException,
     PyiCloudAuthRequiredException,
+    PyiCloudEndpointGoneException,
     PyiCloudServiceNotActivatedException,
 )
 
@@ -53,6 +56,25 @@ NON_PERSISTED_SESSION_KEYS = frozenset({
     "topics_by_hash",
     "txnid",
 })
+
+
+def describe_endpoint(url: str | bytes) -> str:
+    """Return a host-and-path label for ``url``, safe to quote in a bug report.
+
+    Drops the query string, which carries the dsid and client identifiers, and
+    masks long numeric path segments, since Apple's content hosts put the dsid
+    in the path rather than the query.
+    """
+
+    text: str = url.decode("utf-8", "replace") if isinstance(url, bytes) else str(url)
+    parts = urlsplit(text)
+    segments: list[str] = [
+        "<id>" if segment.isdigit() and len(segment) >= 6 else segment
+        for segment in parts.path.split("/")
+    ]
+    host: str = parts.netloc.split("@")[-1]
+    route: str = "/".join(segments)
+    return f"{host}{route}" if host else route
 
 
 class PyiCloudSession(requests.Session):
@@ -310,6 +332,12 @@ class PyiCloudSession(requests.Session):
             self._save_session_data()
 
             status_code: int = int(response.status_code)
+
+            # Checked before the JSON/auth branching below, so a withdrawn
+            # endpoint is reported the same way whether or not Apple bothers to
+            # send a JSON body with it.
+            if status_code == HTTP_GONE:
+                raise PyiCloudEndpointGoneException(describe_endpoint(url), response)
 
             if not response.ok and (
                 self._is_json_response(response)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1376,7 +1376,13 @@ def test_request_reports_a_withdrawn_endpoint(
 
     Apple sent a JSON body when it withdrew the Photos upload endpoint, but
     nothing guarantees that, so the signal is taken from the status code.
+
+    Both bodies here are non-empty and carry an identifier, because
+    ``PyiCloudAPIResponseException`` appends ``response.text`` to the message
+    and an empty body would let that leak past the assertions below.
     """
+
+    dsid = "108580123"
 
     with (
         patch("requests.Session.request") as mock_request,
@@ -1386,13 +1392,15 @@ def test_request_reports_a_withdrawn_endpoint(
         mock_response = MagicMock()
         mock_response.status_code = 410
         mock_response.ok = False
-        mock_response.text = ""
         if json_body:
+            body = f'{{"errorReason": "Gone", "errorCode": 410, "dsid": "{dsid}"}}'
             mock_response.json.return_value = {"errorReason": "Gone", "errorCode": 410}
             mock_response.headers.get.return_value = "application/json"
         else:
+            body = f"<html><body>Gone (dsid {dsid})</body></html>"
             mock_response.json.side_effect = ValueError("not json")
             mock_response.headers.get.return_value = "text/html"
+        mock_response.text = body
         mock_request.return_value = mock_response
         pyicloud_session = PyiCloudSession(
             pyicloud_service_working, "", cookie_directory=""
@@ -1408,10 +1416,15 @@ def test_request_reports_a_withdrawn_endpoint(
     error = excinfo.value
     assert error.code == 410
     assert error.endpoint == "p31-uploadimagews.icloud.com:443/upload"
-    # The message is meant to be pasted into a bug report.
+    # The message is meant to be pasted into a bug report, so neither the URL
+    # nor the response body may contribute an identifier to it.
     assert "dsid" not in str(error)
-    assert "108580123" not in str(error)
+    assert dsid not in str(error)
+    assert body not in str(error)
     assert "github.com/timlaing/pyicloud/issues" in str(error)
+    # Withheld from the message, not discarded: the whole response, body
+    # included, is still attached for debugging.
+    assert error.response is mock_response
     # Existing handlers must keep catching it.
     assert isinstance(error, PyiCloudAPIResponseException)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -24,6 +24,7 @@ from pyicloud.exceptions import (
     PyiCloud2SARequiredException,
     PyiCloudAcceptTermsException,
     PyiCloudAPIResponseException,
+    PyiCloudEndpointGoneException,
     PyiCloudFailedLoginException,
     PyiCloudServiceNotActivatedException,
     PyiCloudServiceUnavailable,
@@ -37,7 +38,7 @@ from pyicloud.services.notes import NotesService
 from pyicloud.services.photos import PhotosService
 from pyicloud.services.reminders import RemindersService
 from pyicloud.services.ubiquity import UbiquityService
-from pyicloud.session import PyiCloudSession
+from pyicloud.session import PyiCloudSession, describe_endpoint
 from pyicloud.utils import b64_encode
 from tests.const import LOGIN_2FA, LOGIN_WORKING
 
@@ -1329,6 +1330,90 @@ def test_request_failure(pyicloud_service_working: PyiCloudService) -> None:
         )
         mock_save.assert_called_once()
         assert open_mock.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # Query strings carry the dsid and client identifiers.
+        (
+            "https://p31-uploadimagews.icloud.com/upload?f=a.jpg&dsid=108580123",
+            "p31-uploadimagews.icloud.com/upload",
+        ),
+        # Content hosts put the dsid in the path instead.
+        (
+            "https://cws.icloud-content.com:443/108580123/singleFileUpload?tk=secret",
+            "cws.icloud-content.com:443/<id>/singleFileUpload",
+        ),
+        # Credentials in the netloc are dropped with the userinfo.
+        (
+            "https://user:pw@p51-drivews.icloud.com/ws/com.apple.CloudDocs",
+            "p51-drivews.icloud.com/ws/com.apple.CloudDocs",
+        ),
+        # Short numeric segments are route structure, not identifiers.
+        (
+            "https://p51-ckdatabasews.icloud.com/database/1/com.apple.photos/records",
+            "p51-ckdatabasews.icloud.com/database/1/com.apple.photos/records",
+        ),
+        (b"https://example.com/path?token=secret", "example.com/path"),
+    ],
+)
+def test_describe_endpoint_is_safe_to_quote(url: str | bytes, expected: str) -> None:
+    """The endpoint label identifies the route without leaking identifiers."""
+
+    label = describe_endpoint(url)
+    assert label == expected
+    assert "secret" not in label
+    assert "108580123" not in label
+
+
+@pytest.mark.parametrize("json_body", [True, False])
+def test_request_reports_a_withdrawn_endpoint(
+    pyicloud_service_working: PyiCloudService,
+    json_body: bool,
+) -> None:
+    """A 410 identifies itself as a withdrawn endpoint, body or no body.
+
+    Apple sent a JSON body when it withdrew the Photos upload endpoint, but
+    nothing guarantees that, so the signal is taken from the status code.
+    """
+
+    with (
+        patch("requests.Session.request") as mock_request,
+        patch("builtins.open", new_callable=mock_open),
+        patch("http.cookiejar.LWPCookieJar.save"),
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 410
+        mock_response.ok = False
+        mock_response.text = ""
+        if json_body:
+            mock_response.json.return_value = {"errorReason": "Gone", "errorCode": 410}
+            mock_response.headers.get.return_value = "application/json"
+        else:
+            mock_response.json.side_effect = ValueError("not json")
+            mock_response.headers.get.return_value = "text/html"
+        mock_request.return_value = mock_response
+        pyicloud_session = PyiCloudSession(
+            pyicloud_service_working, "", cookie_directory=""
+        )
+
+        with pytest.raises(PyiCloudEndpointGoneException) as excinfo:
+            pyicloud_session.request(
+                "POST",
+                "https://p31-uploadimagews.icloud.com:443/upload"
+                "?filename=cat.jpg&dsid=108580123",
+            )
+
+    error = excinfo.value
+    assert error.code == 410
+    assert error.endpoint == "p31-uploadimagews.icloud.com:443/upload"
+    # The message is meant to be pasted into a bug report.
+    assert "dsid" not in str(error)
+    assert "108580123" not in str(error)
+    assert "github.com/timlaing/pyicloud/issues" in str(error)
+    # Existing handlers must keep catching it.
+    assert isinstance(error, PyiCloudAPIResponseException)
 
 
 def test_request_raw_normalizes_transport_failure(


### PR DESCRIPTION
## Proposed change

Apple withdraws endpoints without notice, and answers the withdrawn ones with `410 Gone`.
Until now that arrived as a plain `PyiCloudAPIResponseException`, indistinguishable from a
request the caller got wrong — so the work of proving it was upstream fell to whoever hit it
first.

#316 shows what that costs. Before concluding the endpoint itself had gone, the reporter
ruled out a stale session, an outdated client, a missing PCS handshake, the wrong dsid, the
wrong partition, minimal versus full service params, missing `Origin`/`Referer` headers, two
different backend rollout pods, and the shared zone. Nine hypotheses, all to reach a
conclusion the status code had already stated.

A `410` now raises `PyiCloudEndpointGoneException`:

```
Apple no longer serves p31-uploadimagews.icloud.com/upload. This endpoint appears to
have been withdrawn, which means pyicloud needs updating rather than that your request
was wrong. Please report it at https://github.com/timlaing/pyicloud/issues and quote
this endpoint (410)
```

The intent is that a user who hits the next withdrawal opens an issue naming the endpoint on
day one, instead of spending a day proving it isn't their code.

### Three decisions worth reviewing

**Only `410`, never `404`.** A 404 routinely means a missing record rather than a missing
endpoint, and mislabelling those would be worse than the generic error this replaces. `410`
means *permanently gone* and is unambiguous. If a legitimate 410 turns up somewhere in the
API, the check is one condition and easy to narrow.

**Keyed on the status code, not the error body.** Apple happened to send JSON with the 410 in
#316, but nothing guarantees that, so the check sits before the existing JSON and auth
branching. Both shapes are covered by tests.

**The endpoint label is built to be pasted in public.** `describe_endpoint()` drops the query
string, which carries the dsid and client identifiers, and masks long numeric path segments,
because the content hosts put the dsid in the *path* rather than the query
(`cws.icloud-content.com/<dsid>/singleFileUpload`). Short numeric segments are left alone,
since those are route structure — `/database/1/com.apple.photos/...`. All five cases are
parametrised in the tests, because the value of the message depends entirely on it being safe
to quote.

The response body is withheld from the message for the same reason.
`PyiCloudAPIResponseException` appends `response.text`, which would have put the dsid straight
back into the string the URL redaction had just removed it from, so this subclass attaches the
response itself instead of passing it up. The full body stays available on `error.response`
for debugging; the parent's behaviour is unchanged for every other exception.

### Compatibility

`PyiCloudEndpointGoneException` subclasses `PyiCloudAPIResponseException` and sets `code` to
`410`, so existing `except` handlers and any `code == 410` checks keep working unchanged.
There is an explicit assertion for this rather than an assumption.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:

```python
from pyicloud import PyiCloudService
from pyicloud.exceptions import PyiCloudEndpointGoneException

api = PyiCloudService("jappleseed@apple.com", "password")

try:
    api.photos.upload("./photo.jpg")
except PyiCloudEndpointGoneException as error:
    # error.endpoint is a redacted host-and-path label, safe to quote in an issue
    print(f"pyicloud needs updating for: {error.endpoint}")
```

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #316, where the diagnostic cost of the generic error is
  visible in the report itself

Independent of #331: this branch is cut from `main` and touches only `pyicloud/exceptions.py`,
`pyicloud/session.py` and `tests/test_base.py`. It does share `tests/test_base.py` with that
PR, but in a different region — I verified with a trial three-way merge that the two combine
cleanly, so they can be reviewed and merged in either order.

This is one of the smaller pieces from a retrospective on how the `uploadimagews` withdrawal
was handled, and it stands on its own. The larger idea from that retrospective — an
`icloud doctor` command — is a separate conversation and deliberately not part of this PR.

**Testing.** 847 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally: the
workflows now trigger only on `main`, so a fork branch gets no CI of its own until you approve
the run. Seven of those tests are new — five covering the redaction cases above, two covering
a `410` with and without a JSON body.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README

