### PR TITLE
feat: add an inventory of the webservices the library depends on

### DIFF
--- a/pyicloud/endpoints.py
+++ b/pyicloud/endpoints.py
@@ -1,0 +1,120 @@
+"""Inventory of the Apple webservices this library depends on.
+
+Apple advertises a ``webservices`` map at login and changes it over time: hosts
+move between partitions, keys are added, and endpoints are withdrawn. Until now
+the set of keys pyicloud relies on could only be recovered by grepping for
+``get_webservice_url`` calls scattered across the service properties, which made
+two ordinary questions harder to answer than they should be -- what is this
+library exposed to, and what breaks if Apple stops advertising a given key.
+
+This module answers both in one place. It is deliberately data, not behaviour:
+``get_webservice_url()`` does not consult it, because callers may legitimately
+resolve keys for services pyicloud does not wrap. What keeps it honest is a test
+that scans the source for resolved keys and fails if the two ever disagree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Webservice:
+    """One key in Apple's ``webservices`` map that pyicloud resolves.
+
+    ``powers`` names the ``PyiCloudService`` properties that depend on the key,
+    so the blast radius of a missing host is readable without tracing calls.
+    """
+
+    key: str
+    powers: tuple[str, ...]
+    description: str
+
+
+WEBSERVICES: tuple[Webservice, ...] = (
+    Webservice(
+        key="account",
+        powers=("account",),
+        description="Account details, storage usage, and family members.",
+    ),
+    Webservice(
+        key="calendar",
+        powers=("calendar",),
+        description="Calendar collections and events.",
+    ),
+    Webservice(
+        key="ckdatabasews",
+        powers=("photos", "reminders", "notes", "invites"),
+        description=(
+            "CloudKit database. The most heavily shared host in the library: "
+            "four services are unavailable without it."
+        ),
+    ),
+    Webservice(
+        key="contacts",
+        powers=("contacts",),
+        description="Contact records and the account's own card.",
+    ),
+    Webservice(
+        key="docws",
+        powers=("drive",),
+        description="iCloud Drive document uploads and downloads.",
+    ),
+    Webservice(
+        key="drivews",
+        powers=("drive",),
+        description="iCloud Drive folder structure and file metadata.",
+    ),
+    Webservice(
+        key="findme",
+        powers=("devices",),
+        description="Find My iPhone device list and location.",
+    ),
+    Webservice(
+        key="premiummailsettings",
+        powers=("hidemyemail",),
+        description="Hide My Email address generation and management.",
+    ),
+    Webservice(
+        key="sharedstreams",
+        powers=("photos",),
+        description=(
+            "Legacy shared photo streams. Backs one Photos feature rather than "
+            "the service as a whole."
+        ),
+    ),
+    Webservice(
+        key="ubiquity",
+        powers=("files",),
+        description="Legacy iCloud Documents, superseded by iCloud Drive.",
+    ),
+    Webservice(
+        key="uploadimagews",
+        powers=("photos",),
+        description=(
+            "Original single-POST Photos upload host. Apple withdrew the "
+            "endpoint it serves, which returns HTTP 410 Gone."
+        ),
+    ),
+)
+
+WEBSERVICE_KEYS: frozenset[str] = frozenset(entry.key for entry in WEBSERVICES)
+
+
+def webservice(key: str) -> Webservice | None:
+    """Return the inventory entry for ``key``, or None if it is not one we use."""
+
+    return next((entry for entry in WEBSERVICES if entry.key == key), None)
+
+
+def webservices_for(service: str) -> tuple[str, ...]:
+    """Return the webservice keys the named ``PyiCloudService`` property needs."""
+
+    return tuple(entry.key for entry in WEBSERVICES if service in entry.powers)
+
+
+def services_using(key: str) -> tuple[str, ...]:
+    """Return the service properties that stop working without ``key``."""
+
+    entry = webservice(key)
+    return entry.powers if entry else ()

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -7,6 +7,8 @@ and the inventory disagree in either direction.
 
 from __future__ import annotations
 
+import ast
+from collections.abc import Iterator
 from pathlib import Path
 import re
 
@@ -34,6 +36,45 @@ def _keys_resolved_in_source() -> set[str]:
     return found
 
 
+def _resolved_key(call: ast.Call) -> str | None:
+    """Return the literal webservice key ``call`` resolves, if it resolves one."""
+
+    func = call.func
+    if not isinstance(func, ast.Attribute) or not func.attr.endswith("webservice_url"):
+        return None
+    if not call.args or not isinstance(call.args[0], ast.Constant):
+        return None
+    key = call.args[0].value
+    return key if isinstance(key, str) else None
+
+
+def _calls_directly_in(node: ast.AST) -> Iterator[ast.Call]:
+    """Yield the calls ``node`` makes itself, not those a nested function makes."""
+
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if isinstance(child, ast.Call):
+            yield child
+        yield from _calls_directly_in(child)
+
+
+def _powers_derived_from_source() -> dict[str, set[str]]:
+    """Map each resolved key to the service properties that resolve it."""
+
+    derived: dict[str, set[str]] = {}
+    for source in PACKAGE_ROOT.rglob("*.py"):
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for call in _calls_directly_in(node):
+                key = _resolved_key(call)
+                if key is not None:
+                    derived.setdefault(key, set()).add(node.name)
+    return derived
+
+
 def test_inventory_matches_the_keys_the_library_resolves() -> None:
     """The inventory and the source must not drift apart.
 
@@ -55,6 +96,30 @@ def test_inventory_matches_the_keys_the_library_resolves() -> None:
     assert not stale, (
         f"listed in the inventory but never resolved: {sorted(stale)}. "
         "Remove them from pyicloud/endpoints.py."
+    )
+
+
+def test_inventory_records_which_services_depend_on_each_key() -> None:
+    """``powers`` must match the code, not the maintainer's memory of it.
+
+    The key scan above proves the inventory lists the right keys. This proves
+    it attributes them to the right services, which is the question the module
+    exists to answer -- without it, half the data can rot unnoticed.
+
+    Every resolver call sits inside the service property that needs it, so the
+    enclosing function name is the service. If a call is ever factored out into
+    a helper, the helper's name appears in the diff below: that is a signal to
+    re-express the mapping, not evidence the inventory is wrong.
+    """
+
+    derived = _powers_derived_from_source()
+    declared = {entry.key: set(entry.powers) for entry in WEBSERVICES}
+
+    assert derived == declared, (
+        "pyicloud/endpoints.py and the source disagree about which services "
+        "depend on which key. Update the `powers` of the entries below, or "
+        "move the resolver call back inside the service property if a helper "
+        "now stands between them."
     )
 
 
@@ -98,5 +163,4 @@ def test_cloudkit_is_recorded_as_the_shared_dependency() -> None:
 
     entry = webservice("ckdatabasews")
     assert entry is not None
-    assert set(entry.powers) >= {"photos", "reminders", "notes"}
-    assert len(entry.powers) > 1
+    assert set(entry.powers) == {"photos", "reminders", "notes", "invites"}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,102 @@
+"""Tests for the webservice inventory.
+
+The inventory is only worth having if it stays true, so the important test here
+scans the library source for resolved webservice keys and fails when the code
+and the inventory disagree in either direction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+from pyicloud.endpoints import (
+    WEBSERVICE_KEYS,
+    WEBSERVICES,
+    services_using,
+    webservice,
+    webservices_for,
+)
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "pyicloud"
+
+# Matches get_webservice_url("key") and any future sibling resolver, so adding a
+# tolerant variant does not silently escape this check.
+RESOLVER = re.compile(r"""webservice_url\(\s*["']([a-zA-Z0-9_]+)["']\s*\)""")
+
+
+def _keys_resolved_in_source() -> set[str]:
+    """Return every webservice key the library resolves by literal name."""
+
+    found: set[str] = set()
+    for source in PACKAGE_ROOT.rglob("*.py"):
+        found.update(RESOLVER.findall(source.read_text(encoding="utf-8")))
+    return found
+
+
+def test_inventory_matches_the_keys_the_library_resolves() -> None:
+    """The inventory and the source must not drift apart.
+
+    A key resolved but unlisted means the inventory understates our exposure; a
+    key listed but never resolved means it is stale. Both are failures.
+    """
+
+    resolved = _keys_resolved_in_source()
+
+    assert resolved, "found no webservice lookups; the source scan is broken"
+
+    unlisted = resolved - WEBSERVICE_KEYS
+    assert not unlisted, (
+        f"resolved in code but missing from the inventory: {sorted(unlisted)}. "
+        "Add them to pyicloud/endpoints.py."
+    )
+
+    stale = WEBSERVICE_KEYS - resolved
+    assert not stale, (
+        f"listed in the inventory but never resolved: {sorted(stale)}. "
+        "Remove them from pyicloud/endpoints.py."
+    )
+
+
+def test_inventory_entries_are_well_formed() -> None:
+    """Every entry names at least one service and describes itself."""
+
+    for entry in WEBSERVICES:
+        assert entry.key, "an entry has no key"
+        assert entry.powers, f"{entry.key} names no service that depends on it"
+        assert entry.description.strip(), f"{entry.key} has no description"
+
+
+def test_inventory_keys_are_unique_and_sorted() -> None:
+    """Keys are unique, and kept in order so additions produce clean diffs."""
+
+    keys = [entry.key for entry in WEBSERVICES]
+    assert len(keys) == len(set(keys)), "duplicate keys in the inventory"
+    assert keys == sorted(keys), "inventory is not in key order"
+
+
+def test_lookup_helpers_agree_with_the_inventory() -> None:
+    """The helpers are consistent with the data they read."""
+
+    for entry in WEBSERVICES:
+        assert webservice(entry.key) is entry
+        assert services_using(entry.key) == entry.powers
+        for service in entry.powers:
+            assert entry.key in webservices_for(service)
+
+    assert webservice("not-a-real-webservice") is None
+    assert not services_using("not-a-real-webservice")
+    assert not webservices_for("not-a-real-service")
+
+
+def test_cloudkit_is_recorded_as_the_shared_dependency() -> None:
+    """`ckdatabasews` backs several services, which is worth asserting.
+
+    It is the widest blast radius in the inventory, so a change that narrowed it
+    by accident should fail rather than pass quietly.
+    """
+
+    entry = webservice("ckdatabasews")
+    assert entry is not None
+    assert set(entry.powers) >= {"photos", "reminders", "notes"}
+    assert len(entry.powers) > 1


### PR DESCRIPTION
## Proposed change

Apple advertises a `webservices` map at login and reshapes it over time — hosts move
between partitions, keys appear, and endpoints get withdrawn. Which of those keys pyicloud
actually depends on could previously only be recovered by grepping `get_webservice_url`
calls spread across eleven service properties, which makes two ordinary questions harder
than they should be: what is this library exposed to, and what stops working if Apple drops
a given key.

`pyicloud/endpoints.py` records all eleven, each with the service properties that depend on
it and a short description.

It is data rather than behaviour. `get_webservice_url()` deliberately does **not** consult
it, because callers may legitimately resolve keys for services this library does not wrap —
validating against our list would break them. Nothing existing changes; this adds two files.

### The test is the point

An inventory nobody enforces is stale within a month, so
`test_inventory_matches_the_keys_the_library_resolves` scans the package source for resolved
keys and fails in both directions: a key resolved but unlisted understates the exposure, and
a key listed but never resolved is stale.

I verified both directions by introducing each kind of drift rather than assuming the test
works:

```
AssertionError: resolved in code but missing from the inventory: ['sharedstreams'].
                Add them to pyicloud/endpoints.py.
AssertionError: listed in the inventory but never resolved: ['aaa-phantom'].
                Remove them from pyicloud/endpoints.py.
```

That test reads the package source, which is the mechanism rather than an oversight —
mocking it would leave it asserting nothing. Related to #333.

Enforcing the keys alone would still let the other half of the data rot, because nothing
checked which services each key was attributed to. A second test derives that mapping from
the AST — every resolver call sits inside the service property that needs it, so the
enclosing function is the service — and compares it against what the inventory declares. It
reproduces all eleven entries exactly today, and I verified it against three kinds of drift:
dropping a service from an entry, misattributing a key, and a property starting to resolve a
key it did not before.

```
AssertionError: pyicloud/endpoints.py and the source disagree about which services depend
                on which key. […]
Differing items:
{'ubiquity': {'files'}} != {'ubiquity': {'drive'}}
```

The one way this test can mislead is a refactor that moves a resolver call into a helper: the
helper's name would then appear as the service. The failure message names that case, since it
calls for re-expressing the mapping rather than editing the inventory.

### What it makes visible

`ckdatabasews` alone backs four services — photos, reminders, notes and invites — which is
by far the widest blast radius in the library and was not written down anywhere.
`sharedstreams` and `uploadimagews` back a single Photos feature each. Same information that
made the guard bugs in #331 findable, now readable without tracing calls.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #316, and #333 for the source-reading note above

**Please read this before merging alongside #331.** The two branches merge cleanly as text,
but not as behaviour. #331 introduces a twelfth resolved key, `photosupload`, so whichever
merges second leaves the anti-drift test failing until one entry is added to the inventory:

```
AssertionError: resolved in code but missing from the inventory: ['photosupload'].
```

I confirmed this by merging the two branches locally and running the suite, rather than
inferring it from a clean `merge-tree`. I have deliberately not pre-added the entry, because
on `main` today nothing resolves `photosupload`, so listing it would fail the test in the
other direction. It is a one-line addition once #331 lands, and the failure message names
exactly what to do — which is the mechanism working as intended rather than a defect.

Two things left out on purpose:

- **No required-versus-optional flag.** #331 establishes that three of these keys back a
  single feature while the rest are service roots, so a missing one should disable a feature
  rather than a whole service. Encoding that here would duplicate work in an unmerged branch
  or contradict `main`'s current behaviour. The structure has an obvious slot for it.
- **No probing or health-checking.** This is only the list. Anything that calls these
  endpoints is a separate conversation.

**Testing.** 846 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally — the
workflows now trigger only on `main`, so a fork branch has no CI of its own until you approve
the run. Six of those tests are new.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README

