### PR TITLE
fix: report an advertised webservice with no url as unavailable

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -1323,8 +1323,13 @@ class PyiCloudService:
 
     def get_webservice_url(self, ws_key: str) -> str:
         """Get webservice URL, raise an exception if not exists."""
-        entry: dict[str, Any] | None = (
-            self._webservices.get(ws_key) if self._webservices else None
+        # The map is Apple's JSON, and the `webservices` setter takes it
+        # unvalidated, so nothing guarantees either level is really a mapping.
+        # Checking rather than trusting the annotation keeps every shape
+        # arriving here as one library exception instead of an AttributeError.
+        webservices: Any = self._webservices
+        entry: Any = (
+            webservices.get(ws_key) if isinstance(webservices, Mapping) else None
         )
         if entry is None:
             raise PyiCloudServiceNotActivatedException(
@@ -1337,11 +1342,11 @@ class PyiCloudService:
         # the service nor the reason, so callers could not handle it and users
         # could not act on it. An entry without a usable url means the same
         # thing to a caller as one that was never advertised.
-        url: Any = entry.get("url")
+        url: Any = entry.get("url") if isinstance(entry, Mapping) else None
         if not isinstance(url, str) or not url.strip():
             raise PyiCloudServiceNotActivatedException(
                 f"Webservice not available: {ws_key} "
-                "(Apple advertised it without a url)"
+                "(Apple advertised it without a usable url)"
             )
 
         return url

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -1323,12 +1323,28 @@ class PyiCloudService:
 
     def get_webservice_url(self, ws_key: str) -> str:
         """Get webservice URL, raise an exception if not exists."""
-        if self._webservices is None or self._webservices.get(ws_key) is None:
+        entry: dict[str, Any] | None = (
+            self._webservices.get(ws_key) if self._webservices else None
+        )
+        if entry is None:
             raise PyiCloudServiceNotActivatedException(
                 f"Webservice not available: {ws_key}"
             )
 
-        return cast(str, self._webservices[ws_key]["url"])
+        # Apple sometimes advertises a key with an empty entry -- `schoolwork:
+        # {}` is a live example. Indexing ["url"] there raised a bare
+        # KeyError('url'), which is not a PyiCloudException and names neither
+        # the service nor the reason, so callers could not handle it and users
+        # could not act on it. An entry without a usable url means the same
+        # thing to a caller as one that was never advertised.
+        url: Any = entry.get("url")
+        if not isinstance(url, str) or not url.strip():
+            raise PyiCloudServiceNotActivatedException(
+                f"Webservice not available: {ws_key} "
+                "(Apple advertised it without a url)"
+            )
+
+        return url
 
     @property
     def devices(self) -> FindMyiPhoneServiceManager:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -976,7 +976,52 @@ def test_get_webservice_url_rejects_an_entry_without_a_url(
 
     message = str(excinfo.value)
     assert "schoolwork" in message
-    assert "without a url" in message
+    assert "without a usable url" in message
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        pytest.param("https://p51-schoolwork.icloud.com", id="entry-is-a-string"),
+        pytest.param([], id="entry-is-a-list"),
+        pytest.param(42, id="entry-is-a-number"),
+        pytest.param(True, id="entry-is-a-bool"),
+    ],
+)
+def test_get_webservice_url_rejects_an_entry_that_is_not_a_mapping(
+    pyicloud_service: PyiCloudService, entry: Any
+) -> None:
+    """A malformed entry must not escape as an AttributeError.
+
+    The map is Apple's JSON and the `webservices` setter takes it unvalidated,
+    so the annotation is not a guarantee. `.get` on a non-mapping raised
+    AttributeError, which callers catching this library's own errors miss --
+    the same failure mode as the KeyError this exception replaced.
+    """
+
+    pyicloud_service._webservices = {"schoolwork": entry}
+
+    with pytest.raises(PyiCloudServiceNotActivatedException):
+        pyicloud_service.get_webservice_url("schoolwork")
+
+
+@pytest.mark.parametrize(
+    "webservices",
+    [
+        pytest.param("not-a-map", id="map-is-a-string"),
+        pytest.param(["drivews"], id="map-is-a-list"),
+        pytest.param(0, id="map-is-a-number"),
+    ],
+)
+def test_get_webservice_url_rejects_a_map_that_is_not_a_mapping(
+    pyicloud_service: PyiCloudService, webservices: Any
+) -> None:
+    """The same guard applies one level up, where the setter can also be fed."""
+
+    pyicloud_service._webservices = webservices
+
+    with pytest.raises(PyiCloudServiceNotActivatedException):
+        pyicloud_service.get_webservice_url("drivews")
 
 
 def test_get_webservice_url_distinguishes_absent_from_malformed(
@@ -995,8 +1040,8 @@ def test_get_webservice_url_distinguishes_absent_from_malformed(
     with pytest.raises(PyiCloudServiceNotActivatedException) as absent:
         pyicloud_service.get_webservice_url("never-advertised")
 
-    assert "without a url" in str(malformed.value)
-    assert "without a url" not in str(absent.value)
+    assert "without a usable url" in str(malformed.value)
+    assert "without a usable url" not in str(absent.value)
 
 
 def test_get_webservice_url_without_any_map(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -948,6 +948,68 @@ def test_get_webservice_url_failure(pyicloud_service: PyiCloudService) -> None:
         pyicloud_service.get_webservice_url("invalid_key")
 
 
+@pytest.mark.parametrize(
+    "entry",
+    [
+        # The shape a live account actually returns for `schoolwork`.
+        pytest.param({}, id="empty-entry"),
+        pytest.param({"url": None}, id="null-url"),
+        pytest.param({"url": ""}, id="empty-url"),
+        pytest.param({"url": "   "}, id="blank-url"),
+        pytest.param({"status": "active"}, id="status-but-no-url"),
+    ],
+)
+def test_get_webservice_url_rejects_an_entry_without_a_url(
+    pyicloud_service: PyiCloudService, entry: dict[str, Any]
+) -> None:
+    """An advertised key with no usable url must not raise a bare KeyError.
+
+    Apple advertises `schoolwork: {}` on real accounts. Indexing ["url"] there
+    raised KeyError('url'), which is not a PyiCloudException, so callers could
+    not catch it alongside the not-activated case it is equivalent to.
+    """
+
+    pyicloud_service._webservices = {"schoolwork": entry}
+
+    with pytest.raises(PyiCloudServiceNotActivatedException) as excinfo:
+        pyicloud_service.get_webservice_url("schoolwork")
+
+    message = str(excinfo.value)
+    assert "schoolwork" in message
+    assert "without a url" in message
+
+
+def test_get_webservice_url_distinguishes_absent_from_malformed(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """Both raise the same type, but the message says which happened.
+
+    The distinction is upstream state worth quoting in a bug report: Apple not
+    advertising a key at all is a different event from advertising it broken.
+    """
+
+    pyicloud_service._webservices = {"schoolwork": {}}
+
+    with pytest.raises(PyiCloudServiceNotActivatedException) as malformed:
+        pyicloud_service.get_webservice_url("schoolwork")
+    with pytest.raises(PyiCloudServiceNotActivatedException) as absent:
+        pyicloud_service.get_webservice_url("never-advertised")
+
+    assert "without a url" in str(malformed.value)
+    assert "without a url" not in str(absent.value)
+
+
+def test_get_webservice_url_without_any_map(
+    pyicloud_service: PyiCloudService,
+) -> None:
+    """Resolving before authentication reports the service as unavailable."""
+
+    pyicloud_service._webservices = None
+
+    with pytest.raises(PyiCloudServiceNotActivatedException):
+        pyicloud_service.get_webservice_url("drivews")
+
+
 def test_trust_session_success(pyicloud_service: PyiCloudService) -> None:
     """Test the trust_session method with a successful response."""
 


### PR DESCRIPTION
## Proposed change

Apple advertises `schoolwork: {}` on real accounts — a key present in the `webservices`
map with an empty entry. `get_webservice_url()` guarded only against the key being
*absent*, then indexed `["url"]` directly:

```python
if self._webservices is None or self._webservices.get(ws_key) is None:
    raise PyiCloudServiceNotActivatedException(f"Webservice not available: {ws_key}")

return cast(str, self._webservices[ws_key]["url"])
```

So that shape fell through the guard and raised a bare `KeyError('url')`. On my account,
resolving every advertised key gives:

```
resolved
    account, archivews, calendar, ckdatabasews, … uploadimagews   (32 keys)

KeyError: 'url'
    schoolwork
```

That is the wrong failure in three ways. It is not a `PyiCloudException`, so a caller
catching the library's own errors misses it entirely. The message names neither the service
nor the reason — `'url'` is all you get. And it fires for a condition that means exactly
what the not-activated case already means: the service cannot be used.

An entry whose url is missing, `null`, or blank now raises
`PyiCloudServiceNotActivatedException`:

```
Webservice not available: schoolwork (Apple advertised it without a url)
```

### Two decisions worth reviewing

**The same exception type, not a new one.** A caller cannot act differently on "not
advertised" versus "advertised broken" — either way the service is unusable — so this
reuses `PyiCloudServiceNotActivatedException` rather than adding a class. Existing `except`
blocks keep working unchanged, and the shape that used to escape them now doesn't.

**The message still distinguishes them.** The two are different *upstream* events, and that
distinction is worth quoting in a bug report even though the handling is identical. Only the
malformed case carries the parenthetical, and there is a test asserting the absent case does
not.

`"url"` must be a non-empty string to count as advertised, so `{}`, `{"url": null}`,
`{"url": ""}` and `{"url": "   "}` are all treated alike. Each is a separate parametrised
case.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #316 — this is the loose end disclosed in #332's description
  and left unfixed at the time

Cut from `main` and touches only `pyicloud/base.py` and `tests/test_base.py`, so it is
independent of #331, #334, #335 and #336 and can merge in any order relative to them.

**One follow-up on #336.** That PR's `icloud doctor` describes this exact condition with
the words "get_webservice_url() would raise KeyError on it", which this change makes
untrue. I will update that wording on the doctor branch; it is text only, and the
classification itself stays correct — the doctor should still report a malformed entry,
because Apple advertising a key broken is worth seeing even now that resolving it fails
cleanly.

**Testing.** 847 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally — the
workflows trigger only on `main`, so a fork branch has no CI of its own until you approve
the run. Seven of those tests are new; six of them fail against the previous code, which I
checked by running them against it rather than assuming the new assertions bite. (The
seventh covers resolving before authentication, which already worked and is there as a
regression guard.)

Verified live rather than only against fixtures, since the whole point is a shape Apple
actually sends:

- Before: 32 of 33 advertised keys resolve, `schoolwork` raises `KeyError: 'url'`.
- After: the same 32 resolve unchanged, `schoolwork` raises the message above.
- The public service properties — `account.storage`, `drive.root`, `calendar`, `contacts`,
  `photos`, `devices`, `files` — were exercised before and after and behave identically,
  including the two that fail for unrelated reasons on this account (Find My wants a
  password; Ubiquity reports the account migrated). That comparison is the reason I can say
  those two are not regressions.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
