### PR TITLE
fix(invites): read the shared scope zone by zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,90 @@ _adds a calendar to the users apple calendar_
 **remove_calendar(cal_guid:str) -> None**<br>
 _Removes a Calendar from the apple calendar given the provided guid_
 
-#### Examples
+#### Invites
+
+Apple Invites events, read and RSVP. Events you created live in your private
+library; events other people shared with you arrive in the shared one, and both
+are returned together.
+
+_List every event you can see:_
+
+```python
+api = PyiCloudService("jappleseed@apple.com", "password")
+
+for event in api.invites.events():
+    print(event.scope.value, event.event_id, event.title)
+```
+
+`scope` is `EventScope.PRIVATE` for events you own and `EventScope.SHARED` for
+events shared with you. The listing is a summary: `share` and `rsvps` are not
+populated. Use `event()` for a full view.
+
+_Fetch one event with its share and responses:_
+
+```python
+event = api.invites.event("EVENT-UUID")
+
+print(event.title, event.host_display_name)
+print(event.time.start, event.time.end, event.time.is_all_day)
+print(event.place.title, event.place.city)
+
+for rsvp in api.invites.rsvps(event):
+    print(rsvp.name, rsvp.status.name, rsvp.num_additional_adults)
+```
+
+`event()` looks in your private events first, then the shared ones, and raises
+`EventNotFound` if neither has it.
+
+### Responding to an invitation
+
+```python
+from pyicloud.services.invites import RsvpStatus
+
+event = api.invites.event("EVENT-UUID")
+
+api.invites.rsvp(
+    event,
+    RsvpStatus.GOING,
+    name="Jane Appleseed",
+    message="Looking forward to it",
+    plus_one_adults=1,
+)
+```
+
+`RsvpStatus` is `NO_RESPONSE`, `NOT_GOING`, `MAYBE` or `GOING`. Calling `rsvp()`
+again updates your existing response rather than adding another. Choosing
+`NOT_GOING` clears the plus-one counts, matching what the iCloud web interface
+does.
+
+### Joining an event from an invite link
+
+An invite link looks like `https://www.icloud.com/invites/008ABCDEFGHIJ`. The
+trailing part is the short guid.
+
+```python
+preview = api.invites.resolve("008ABCDEFGHIJ")
+print(preview.owner_given_name, preview.participant_status)
+
+event = api.invites.accept("008ABCDEFGHIJ")
+print(event.scope.value)  # shared
+```
+
+On `ResolvedShare`, `participant_status`, `participant_type` and
+`participant_permission` are plain strings as Apple returns them, not the
+enums used elsewhere in this service.
+
+`resolve()` only looks; `accept()` joins the event, after which it appears in
+`events()` with the shared scope.
+
+### Errors
+
+Every call raises a subclass of `InvitesError`: `InvitesAuthError` when the
+session needs renewing, `InvitesRateLimited` when Apple asks you to slow down,
+and `InvitesApiError` for everything else. `event()` raises `EventNotFound` for
+an unknown event id.
+
+## Examples
 
 _Create and add a new calendar:_
 

--- a/README.md
+++ b/README.md
@@ -487,90 +487,7 @@ _adds a calendar to the users apple calendar_
 **remove_calendar(cal_guid:str) -> None**<br>
 _Removes a Calendar from the apple calendar given the provided guid_
 
-#### Invites
-
-Apple Invites events, read and RSVP. Events you created live in your private
-library; events other people shared with you arrive in the shared one, and both
-are returned together.
-
-_List every event you can see:_
-
-```python
-api = PyiCloudService("jappleseed@apple.com", "password")
-
-for event in api.invites.events():
-    print(event.scope.value, event.event_id, event.title)
-```
-
-`scope` is `EventScope.PRIVATE` for events you own and `EventScope.SHARED` for
-events shared with you. The listing is a summary: `share` and `rsvps` are not
-populated. Use `event()` for a full view.
-
-_Fetch one event with its share and responses:_
-
-```python
-event = api.invites.event("EVENT-UUID")
-
-print(event.title, event.host_display_name)
-print(event.time.start, event.time.end, event.time.is_all_day)
-print(event.place.title, event.place.city)
-
-for rsvp in api.invites.rsvps(event):
-    print(rsvp.name, rsvp.status.name, rsvp.num_additional_adults)
-```
-
-`event()` looks in your private events first, then the shared ones, and raises
-`EventNotFound` if neither has it.
-
-### Responding to an invitation
-
-```python
-from pyicloud.services.invites import RsvpStatus
-
-event = api.invites.event("EVENT-UUID")
-
-api.invites.rsvp(
-    event,
-    RsvpStatus.GOING,
-    name="Jane Appleseed",
-    message="Looking forward to it",
-    plus_one_adults=1,
-)
-```
-
-`RsvpStatus` is `NO_RESPONSE`, `NOT_GOING`, `MAYBE` or `GOING`. Calling `rsvp()`
-again updates your existing response rather than adding another. Choosing
-`NOT_GOING` clears the plus-one counts, matching what the iCloud web interface
-does.
-
-### Joining an event from an invite link
-
-An invite link looks like `https://www.icloud.com/invites/008ABCDEFGHIJ`. The
-trailing part is the short guid.
-
-```python
-preview = api.invites.resolve("008ABCDEFGHIJ")
-print(preview.owner_given_name, preview.participant_status)
-
-event = api.invites.accept("008ABCDEFGHIJ")
-print(event.scope.value)  # shared
-```
-
-On `ResolvedShare`, `participant_status`, `participant_type` and
-`participant_permission` are plain strings as Apple returns them, not the
-enums used elsewhere in this service.
-
-`resolve()` only looks; `accept()` joins the event, after which it appears in
-`events()` with the shared scope.
-
-### Errors
-
-Every call raises a subclass of `InvitesError`: `InvitesAuthError` when the
-session needs renewing, `InvitesRateLimited` when Apple asks you to slow down,
-and `InvitesApiError` for everything else. `event()` raises `EventNotFound` for
-an unknown event id.
-
-## Examples
+#### Examples
 
 _Create and add a new calendar:_
 
@@ -1680,6 +1597,89 @@ Important CLI flags:
 
 `--download-assets` is no longer supported in the example CLI. Use
 `--export-mode` to choose between archival and lightweight export behavior.
+
+## Invites
+
+Apple Invites events, read and RSVP. Events you created live in your private
+library; events other people shared with you arrive in the shared one, and both
+are returned together.
+
+_List every event you can see:_
+
+```python
+api = PyiCloudService("jappleseed@apple.com", "password")
+
+for event in api.invites.events():
+    print(event.scope.value, event.event_id, event.title)
+```
+
+`scope` is `EventScope.PRIVATE` for events you own and `EventScope.SHARED` for
+events shared with you. The listing is a summary: `share` and `rsvps` are not
+populated. Use `event()` for a full view.
+
+_Fetch one event with its share and responses:_
+
+```python
+event = api.invites.event("EVENT-UUID")
+
+print(event.title, event.host_display_name)
+print(event.time.start, event.time.end, event.time.is_all_day)
+print(event.place.title, event.place.city)
+
+for rsvp in api.invites.rsvps(event):
+    print(rsvp.name, rsvp.status.name, rsvp.num_additional_adults)
+```
+
+`event()` looks in your private events first, then the shared ones, and raises
+`EventNotFound` if neither has it.
+
+### Responding to an invitation
+
+```python
+from pyicloud.services.invites import RsvpStatus
+
+event = api.invites.event("EVENT-UUID")
+
+api.invites.rsvp(
+    event,
+    RsvpStatus.GOING,
+    name="Jane Appleseed",
+    message="Looking forward to it",
+    plus_one_adults=1,
+)
+```
+
+`RsvpStatus` is `NO_RESPONSE`, `NOT_GOING`, `MAYBE` or `GOING`. Calling `rsvp()`
+again updates your existing response rather than adding another. Choosing
+`NOT_GOING` clears the plus-one counts, matching what the iCloud web interface
+does.
+
+### Joining an event from an invite link
+
+An invite link looks like `https://www.icloud.com/invites/008ABCDEFGHIJ`. The
+trailing part is the short guid.
+
+```python
+preview = api.invites.resolve("008ABCDEFGHIJ")
+print(preview.owner_given_name, preview.participant_status)
+
+event = api.invites.accept("008ABCDEFGHIJ")
+print(event.scope.value)  # shared
+```
+
+On `ResolvedShare`, `participant_status`, `participant_type` and
+`participant_permission` are plain strings as Apple returns them, not the
+enums used elsewhere in this service.
+
+`resolve()` only looks; `accept()` joins the event, after which it appears in
+`events()` with the shared scope.
+
+### Errors
+
+Every call raises a subclass of `InvitesError`: `InvitesAuthError` when the
+session needs renewing, `InvitesRateLimited` when Apple asks you to slow down,
+and `InvitesApiError` for everything else. `event()` raises `EventNotFound` for
+an unknown event id.
 
 ## Examples
 

--- a/pyicloud/services/invites/client.py
+++ b/pyicloud/services/invites/client.py
@@ -22,7 +22,7 @@ client; see the Invites design doc.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 import logging
 from typing import Any, Literal, NoReturn, cast
 from urllib.parse import urlencode
@@ -34,6 +34,7 @@ from pyicloud.common.cloudkit import (
     CKQueryObject,
     CKQueryResponse,
     CKZoneChangesResponse,
+    CKZoneChangesZone,
     CKZoneChangesZoneReq,
     CKZoneIDReq,
     CKZoneListResponse,
@@ -51,6 +52,21 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = (10.0, 60.0)
 _UNAUTHORIZED_STATUSES = (401, 403)
 _RATE_LIMITED_STATUS = 429
+
+
+def _status_of(exc: PyiCloudAPIResponseException) -> int | None:
+    """Return the exception's status as an int, whichever form it arrived in.
+
+    ``PyiCloudAPIResponseException.code`` is typed ``int | str | None``, and a
+    string ``"401"`` compared against the int statuses below would silently
+    fall through to a generic error instead of an auth one.
+    """
+
+    try:
+        return int(exc.code) if exc.code is not None else None
+    except (TypeError, ValueError):
+        return None
+
 
 ScopeLiteral = Literal["private", "shared"]
 
@@ -148,9 +164,10 @@ class CloudKitInvitesClient:
             # response first, so the transport error arrives here untranslated
             # and callers catching InvitesError never see it. Map it the same
             # way the HTTP layer would have.
-            if exc.code in _UNAUTHORIZED_STATUSES:
+            status = _status_of(exc)
+            if status in _UNAUTHORIZED_STATUSES:
                 raise InvitesAuthError(str(exc)) from cause
-            if exc.code == _RATE_LIMITED_STATUS:
+            if status == _RATE_LIMITED_STATUS:
                 raise InvitesRateLimited(str(exc)) from cause
             raise InvitesApiError(str(exc)) from cause
         raise exc
@@ -165,6 +182,31 @@ class CloudKitInvitesClient:
         """
         try:
             return self._client_for(scope).zones_list()
+        except (
+            CloudKitApiError,
+            CloudKitAuthError,
+            CloudKitRateLimited,
+            PyiCloudAPIResponseException,
+        ) as exc:
+            self._raise_invites_error(exc)
+
+    def iter_changes(
+        self,
+        scope: ScopeLiteral,
+        *,
+        zone_req: CKZoneChangesZoneReq,
+        results_limit: int | None = None,
+    ) -> Iterator[CKZoneChangesZone]:
+        """Yield every page of a zone's changes, not only the first.
+
+        ``changes()`` returns one page. A zone with ``moreComing`` set has more
+        behind it, and taking only the first page silently drops records.
+        """
+        try:
+            yield from self._client_for(scope).iter_changes(
+                zone_req=zone_req,
+                results_limit=results_limit,
+            )
         except (
             CloudKitApiError,
             CloudKitAuthError,

--- a/pyicloud/services/invites/client.py
+++ b/pyicloud/services/invites/client.py
@@ -36,6 +36,7 @@ from pyicloud.common.cloudkit import (
     CKZoneChangesResponse,
     CKZoneChangesZoneReq,
     CKZoneIDReq,
+    CKZoneListResponse,
     CloudKitExtraMode,
 )
 from pyicloud.common.cloudkit.client import (
@@ -44,9 +45,12 @@ from pyicloud.common.cloudkit.client import (
     CloudKitContainerClient,
     CloudKitRateLimited,
 )
+from pyicloud.exceptions import PyiCloudAPIResponseException
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = (10.0, 60.0)
+_UNAUTHORIZED_STATUSES = (401, 403)
+_RATE_LIMITED_STATUS = 429
 
 ScopeLiteral = Literal["private", "shared"]
 
@@ -138,9 +142,36 @@ class CloudKitInvitesClient:
             raise InvitesRateLimited(str(exc), retry_after=exc.retry_after) from cause
         if isinstance(exc, CloudKitApiError):
             raise InvitesApiError(str(exc), payload=exc.payload) from cause
+        if isinstance(exc, PyiCloudAPIResponseException):
+            # CloudKitHttp.post() maps 4xx onto the CloudKit errors above, but
+            # never gets the chance: PyiCloudSession raises on a non-ok JSON
+            # response first, so the transport error arrives here untranslated
+            # and callers catching InvitesError never see it. Map it the same
+            # way the HTTP layer would have.
+            if exc.code in _UNAUTHORIZED_STATUSES:
+                raise InvitesAuthError(str(exc)) from cause
+            if exc.code == _RATE_LIMITED_STATUS:
+                raise InvitesRateLimited(str(exc)) from cause
+            raise InvitesApiError(str(exc)) from cause
         raise exc
 
     # ----- Records-in-zones scoped wrappers ----------------------------------
+
+    def zones_list(self, scope: ScopeLiteral) -> CKZoneListResponse:
+        """List the zones in the given scope.
+
+        The shared database rejects zone-wide queries, so enumerating it means
+        listing its zones first and reading each one.
+        """
+        try:
+            return self._client_for(scope).zones_list()
+        except (
+            CloudKitApiError,
+            CloudKitAuthError,
+            CloudKitRateLimited,
+            PyiCloudAPIResponseException,
+        ) as exc:
+            self._raise_invites_error(exc)
 
     def query(
         self,
@@ -163,7 +194,12 @@ class CloudKitInvitesClient:
                 continuation=continuation,
                 zone_wide=zone_wide,
             )
-        except (CloudKitApiError, CloudKitAuthError, CloudKitRateLimited) as exc:
+        except (
+            CloudKitApiError,
+            CloudKitAuthError,
+            CloudKitRateLimited,
+            PyiCloudAPIResponseException,
+        ) as exc:
             self._raise_invites_error(exc)
 
     def lookup(
@@ -181,7 +217,12 @@ class CloudKitInvitesClient:
                 zone_id=zone_id,
                 desired_keys=desired_keys,
             )
-        except (CloudKitApiError, CloudKitAuthError, CloudKitRateLimited) as exc:
+        except (
+            CloudKitApiError,
+            CloudKitAuthError,
+            CloudKitRateLimited,
+            PyiCloudAPIResponseException,
+        ) as exc:
             self._raise_invites_error(exc)
 
     def modify(
@@ -199,7 +240,12 @@ class CloudKitInvitesClient:
                 zone_id=zone_id,
                 atomic=atomic,
             )
-        except (CloudKitApiError, CloudKitAuthError, CloudKitRateLimited) as exc:
+        except (
+            CloudKitApiError,
+            CloudKitAuthError,
+            CloudKitRateLimited,
+            PyiCloudAPIResponseException,
+        ) as exc:
             self._raise_invites_error(exc)
 
     def changes(
@@ -215,7 +261,12 @@ class CloudKitInvitesClient:
                 zone_req=zone_req,
                 results_limit=results_limit,
             )
-        except (CloudKitApiError, CloudKitAuthError, CloudKitRateLimited) as exc:
+        except (
+            CloudKitApiError,
+            CloudKitAuthError,
+            CloudKitRateLimited,
+            PyiCloudAPIResponseException,
+        ) as exc:
             self._raise_invites_error(exc)
 
     # ----- Public-scope resolve / accept -------------------------------------
@@ -294,5 +345,10 @@ class CloudKitInvitesClient:
         """Download raw bytes from a CloudKit asset URL via the private scope."""
         try:
             return self._private.download_asset_bytes(url)
-        except (CloudKitApiError, CloudKitAuthError, CloudKitRateLimited) as exc:
+        except (
+            CloudKitApiError,
+            CloudKitAuthError,
+            CloudKitRateLimited,
+            PyiCloudAPIResponseException,
+        ) as exc:
             self._raise_invites_error(exc)

--- a/pyicloud/services/invites/service.py
+++ b/pyicloud/services/invites/service.py
@@ -33,6 +33,7 @@ from pyicloud.common.cloudkit import (
     CKRecord,
     CKWriteFields,
     CKWriteRecord,
+    CKZoneChangesZoneReq,
     CKZoneIDReq,
 )
 from pyicloud.common.cloudkit.base import CloudKitExtraMode
@@ -356,15 +357,36 @@ class InvitesService(BaseService):
             return record_name[len(EVENT_DETAILS_RECORD_NAME_PREFIX) :]
         return record_name
 
-    @staticmethod
-    def _zone_id_req(event_id: str, _scope: EventScope) -> CKZoneIDReq:
-        # In the shared scope CloudKit needs the original owner record name,
-        # but we don't always have it here. Most call sites work with just
-        # zoneName + zoneType; expand if shared writes need ownerRecordName.
+    def _zone_id_req(self, event_id: str, scope: EventScope) -> CKZoneIDReq:
+        """Build the zone reference for an event.
+
+        A shared zone is only addressable with its original owner, so without
+        ownerRecordName a shared lookup finds nothing and the caller sees
+        EventNotFound for an event ``events()`` just returned. The owner comes
+        from the shared /zones/list entry whose zoneName is the event id.
+        """
+
+        owner = (
+            self._shared_zone_owner(event_id) if scope is EventScope.SHARED else None
+        )
         return CKZoneIDReq(
             zoneName=event_id,
             zoneType="REGULAR_CUSTOM_ZONE",
+            ownerRecordName=owner,
         )
+
+    def _shared_zone_owner(self, event_id: str) -> str | None:
+        """Return the owner of the shared zone holding ``event_id``, if any."""
+
+        try:
+            zones = self._raw.zones_list(self._scope_str(EventScope.SHARED)).zones or []
+        except InvitesError:
+            LOGGER.debug("invites.shared_zone_owner_failed", exc_info=True)
+            return None
+        for zone in zones:
+            if zone.zoneID.zoneName == event_id:
+                return zone.zoneID.ownerRecordName
+        return None
 
     @staticmethod
     def _records_of(
@@ -373,6 +395,9 @@ class InvitesService(BaseService):
         return [r for r in resp.records if isinstance(r, CKRecord)]
 
     def _iter_event_details(self, scope: EventScope) -> Iterable[CKRecord]:
+        if scope is EventScope.SHARED:
+            return self._shared_event_details()
+
         try:
             resp = self._raw.query(
                 self._scope_str(scope),
@@ -387,6 +412,46 @@ class InvitesService(BaseService):
             )
             return []
         return self._records_of(resp)
+
+    def _shared_event_details(self) -> list[CKRecord]:
+        """Enumerate shared events one zone at a time.
+
+        CloudKit refuses a zone-wide query against the shared database --
+        "SharedDB does not support Zone Wide queries" -- so the shared scope is
+        read by listing the zones shared with this account and taking the
+        records of each. A zone that fails is skipped rather than failing the
+        whole call, since one unreadable share should not hide the others.
+        """
+
+        scope_str = self._scope_str(EventScope.SHARED)
+        try:
+            zones = self._raw.zones_list(scope_str).zones or []
+        except InvitesError:
+            LOGGER.debug("invites.events.zones_list_failed", exc_info=True)
+            return []
+
+        wanted = InvitesRecordType.EventDetails.value
+        records: list[CKRecord] = []
+        for zone in zones:
+            try:
+                resp = self._raw.changes(
+                    scope_str,
+                    zone_req=CKZoneChangesZoneReq(zoneID=zone.zoneID),
+                )
+            except InvitesError:
+                LOGGER.debug(
+                    "invites.events.zone_changes_failed zone=%s",
+                    zone.zoneID.zoneName,
+                    exc_info=True,
+                )
+                continue
+            records.extend(
+                record
+                for changed in resp.zones
+                for record in changed.records
+                if isinstance(record, CKRecord) and record.recordType == wanted
+            )
+        return records
 
     def _fetch_event_full(self, event_id: str, scope: EventScope) -> Event | None:
         zone_id = self._zone_id_req(event_id, scope)

--- a/pyicloud/services/invites/service.py
+++ b/pyicloud/services/invites/service.py
@@ -434,9 +434,13 @@ class InvitesService(BaseService):
         records: list[CKRecord] = []
         for zone in zones:
             try:
-                resp = self._raw.changes(
-                    scope_str,
-                    zone_req=CKZoneChangesZoneReq(zoneID=zone.zoneID),
+                # Every page, not just the first: a zone with more behind it
+                # would otherwise drop events with no sign anything was lost.
+                pages = list(
+                    self._raw.iter_changes(
+                        scope_str,
+                        zone_req=CKZoneChangesZoneReq(zoneID=zone.zoneID),
+                    )
                 )
             except InvitesError:
                 LOGGER.debug(
@@ -447,8 +451,8 @@ class InvitesService(BaseService):
                 continue
             records.extend(
                 record
-                for changed in resp.zones
-                for record in changed.records
+                for page in pages
+                for record in page.records
                 if isinstance(record, CKRecord) and record.recordType == wanted
             )
         return records

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,5 +1,7 @@
 """Tests for the Invites service."""
 
+# pylint: disable=protected-access
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -16,7 +18,10 @@ from pyicloud.common.cloudkit import (
     CKLookupResponse,
     CKModifyResponse,
     CKQueryResponse,
+    CKZoneChangesResponse,
+    CKZoneListResponse,
 )
+from pyicloud.exceptions import PyiCloudAPIResponseException
 from pyicloud.services.invites import (
     AcceptanceStatus,
     Event,
@@ -183,6 +188,38 @@ class InvitesServiceTest(unittest.TestCase):
             load_invites_fixture("one_time_link_query_empty_response.json")
         )
 
+    @staticmethod
+    def _shared_zone_list() -> CKZoneListResponse:
+        """One zone shared with this account, as /zones/list returns it."""
+        return CKZoneListResponse.model_validate({
+            "zones": [
+                {
+                    "zoneID": {
+                        "zoneName": "SHARED-ZONE-FIXTURE",
+                        "ownerRecordName": "_shared-owner",
+                        "zoneType": "REGULAR_CUSTOM_ZONE",
+                    }
+                }
+            ]
+        })
+
+    @staticmethod
+    def _shared_zone_changes() -> CKZoneChangesResponse:
+        """The shared zone's records, reusing the event fixture's records."""
+        records = load_invites_fixture("events_query_response.json")["records"]
+        return CKZoneChangesResponse.model_validate({
+            "zones": [
+                {
+                    "zoneID": {
+                        "zoneName": "SHARED-ZONE-FIXTURE",
+                        "ownerRecordName": "_shared-owner",
+                    },
+                    "records": records,
+                    "syncToken": "FIXTURE-SYNC-TOKEN",
+                }
+            ]
+        })
+
     def test_events_returns_dtos_from_private_query(self) -> None:
         """events() returns DTOs populated from the private-scope query."""
         # `events()` queries both private and shared. We return the events from
@@ -247,17 +284,20 @@ class InvitesServiceTest(unittest.TestCase):
         self.assertTrue(second.time.is_open_ended)
 
     def test_events_merges_private_and_shared_with_dedup(self) -> None:
-        """events() merges private and shared results and deduplicates them."""
-        # Same event appears in both scopes (defensive dedup). Both passes
-        # should yield distinct (scope, event_id) keys.
-        first_resp = self._events_query_response()
-        # Build a shared-scope response with overlapping records.
-        second_resp = self._events_query_response()
+        """events() merges private and shared results and deduplicates them.
+
+        The two scopes are read by different mechanisms: private is one
+        zone-wide query, while shared has to be enumerated zone by zone.
+        """
+        query_mock = MagicMock(return_value=self._events_query_response())
+        changes_mock = MagicMock(return_value=self._shared_zone_changes())
+        self._monkeypatch.setattr(self.service.raw, "query", query_mock)
         self._monkeypatch.setattr(
             self.service.raw,
-            "query",
-            MagicMock(side_effect=[first_resp, second_resp]),
+            "zones_list",
+            MagicMock(return_value=self._shared_zone_list()),
         )
+        self._monkeypatch.setattr(self.service.raw, "changes", changes_mock)
 
         events = self.service.events()
 
@@ -265,6 +305,159 @@ class InvitesServiceTest(unittest.TestCase):
         self.assertEqual(len(events), 4)
         keys = {(e.scope, e.event_id) for e in events}
         self.assertEqual(len(keys), 4)
+
+    def test_shared_events_are_never_read_with_a_zone_wide_query(self) -> None:
+        """CloudKit rejects zone-wide queries against the shared database.
+
+        The previous implementation issued one anyway, which made events()
+        raise on every account. The old test could not catch that because it
+        mocked the query as succeeding, which the real API never does.
+        """
+        query_mock = MagicMock(return_value=self._events_query_response())
+        self._monkeypatch.setattr(self.service.raw, "query", query_mock)
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "zones_list",
+            MagicMock(return_value=self._shared_zone_list()),
+        )
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "changes",
+            MagicMock(return_value=self._shared_zone_changes()),
+        )
+
+        self.service.events()
+
+        scopes_queried = [call.args[0] for call in query_mock.call_args_list]
+        self.assertEqual(scopes_queried, ["private"])
+        self.assertTrue(
+            all(call.kwargs.get("zone_wide") for call in query_mock.call_args_list)
+        )
+
+    def test_one_unreadable_shared_zone_does_not_hide_the_others(self) -> None:
+        """A share we cannot read must not take down the whole listing."""
+        two_zones = CKZoneListResponse.model_validate({
+            "zones": [
+                {"zoneID": {"zoneName": "BROKEN-ZONE", "ownerRecordName": "_o"}},
+                {
+                    "zoneID": {
+                        "zoneName": "SHARED-ZONE-FIXTURE",
+                        "ownerRecordName": "_shared-owner",
+                    }
+                },
+            ]
+        })
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "query",
+            MagicMock(return_value=CKQueryResponse.model_validate({"records": []})),
+        )
+        self._monkeypatch.setattr(
+            self.service.raw, "zones_list", MagicMock(return_value=two_zones)
+        )
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "changes",
+            MagicMock(
+                side_effect=[
+                    InvitesApiError("boom"),
+                    self._shared_zone_changes(),
+                ]
+            ),
+        )
+
+        events = self.service.events()
+
+        self.assertEqual(len(events), 2)
+        self.assertTrue(all(e.scope is EventScope.SHARED for e in events))
+
+    def test_a_shared_zone_is_addressed_with_its_owner(self) -> None:
+        """A shared zone is only addressable with its original owner.
+
+        Without ownerRecordName the lookup finds nothing, so event() raised
+        EventNotFound for a shared event that events() had just returned.
+        """
+        zones_mock = MagicMock(return_value=self._shared_zone_list())
+        self._monkeypatch.setattr(self.service.raw, "zones_list", zones_mock)
+
+        zone_id = self.service._zone_id_req("SHARED-ZONE-FIXTURE", EventScope.SHARED)
+
+        self.assertEqual(zone_id.zoneName, "SHARED-ZONE-FIXTURE")
+        self.assertEqual(zone_id.ownerRecordName, "_shared-owner")
+
+    def test_a_private_zone_needs_no_owner_and_no_extra_request(self) -> None:
+        """The private scope must not pay for a zone listing it does not need."""
+        zones_mock = MagicMock(return_value=self._shared_zone_list())
+        self._monkeypatch.setattr(self.service.raw, "zones_list", zones_mock)
+
+        zone_id = self.service._zone_id_req("EVENT-AAAA", EventScope.PRIVATE)
+
+        self.assertEqual(zone_id.zoneName, "EVENT-AAAA")
+        self.assertIsNone(zone_id.ownerRecordName)
+        zones_mock.assert_not_called()
+
+    def test_an_unknown_shared_zone_falls_back_to_no_owner(self) -> None:
+        """A zone we cannot resolve must not raise out of zone construction."""
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "zones_list",
+            MagicMock(side_effect=InvitesApiError("nope")),
+        )
+
+        zone_id = self.service._zone_id_req("MISSING-ZONE", EventScope.SHARED)
+
+        self.assertEqual(zone_id.zoneName, "MISSING-ZONE")
+        self.assertIsNone(zone_id.ownerRecordName)
+
+    def test_a_transport_error_reaches_callers_as_an_invites_error(self) -> None:
+        """The session raises before CloudKitHttp can map the status code.
+
+        PyiCloudSession raises PyiCloudAPIResponseException on a non-ok JSON
+        response, so CloudKitHttp.post() never sees the 4xx it is written to
+        translate. Without mapping it at the invites boundary, the service's
+        own `except InvitesError` guards silently do not fire -- which is how a
+        400 from the shared database escaped events() entirely.
+        """
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "query",
+            MagicMock(return_value=self._events_query_response()),
+        )
+        self._monkeypatch.setattr(
+            self.service.raw._private,
+            "zones_list",
+            MagicMock(side_effect=PyiCloudAPIResponseException("Bad Request", 400)),
+        )
+        self._monkeypatch.setattr(
+            self.service.raw._shared,
+            "zones_list",
+            MagicMock(side_effect=PyiCloudAPIResponseException("Bad Request", 400)),
+        )
+
+        with self.assertRaises(InvitesApiError):
+            self.service.raw.zones_list("shared")
+
+        # And the service degrades rather than propagating it.
+        events = self.service.events()
+        self.assertEqual(len(events), 2)
+
+    def test_a_failing_zone_list_yields_no_shared_events(self) -> None:
+        """The shared scope degrades to empty rather than raising."""
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "query",
+            MagicMock(return_value=self._events_query_response()),
+        )
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "zones_list",
+            MagicMock(side_effect=InvitesApiError("nope")),
+        )
+
+        events = self.service.events()
+
+        self.assertEqual(len(events), 2)
+        self.assertTrue(all(e.scope is EventScope.PRIVATE for e in events))
 
     def test_event_full_lookup_includes_share_and_rsvps(self) -> None:
         """A full event lookup returns share and RSVP details."""

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -18,7 +18,7 @@ from pyicloud.common.cloudkit import (
     CKLookupResponse,
     CKModifyResponse,
     CKQueryResponse,
-    CKZoneChangesResponse,
+    CKZoneChangesZone,
     CKZoneListResponse,
 )
 from pyicloud.exceptions import PyiCloudAPIResponseException
@@ -34,7 +34,12 @@ from pyicloud.services.invites import (
     Rsvp,
     RsvpStatus,
 )
-from pyicloud.services.invites.client import InvitesApiError
+from pyicloud.services.invites.client import (
+    CloudKitInvitesClient,
+    InvitesApiError,
+    InvitesAuthError,
+    InvitesRateLimited,
+)
 from pyicloud.services.invites.codecs import (
     decode_integrations,
     decode_json_bytes,
@@ -204,21 +209,26 @@ class InvitesServiceTest(unittest.TestCase):
         })
 
     @staticmethod
-    def _shared_zone_changes() -> CKZoneChangesResponse:
-        """The shared zone's records, reusing the event fixture's records."""
-        records = load_invites_fixture("events_query_response.json")["records"]
-        return CKZoneChangesResponse.model_validate({
-            "zones": [
-                {
-                    "zoneID": {
-                        "zoneName": "SHARED-ZONE-FIXTURE",
-                        "ownerRecordName": "_shared-owner",
-                    },
-                    "records": records,
-                    "syncToken": "FIXTURE-SYNC-TOKEN",
-                }
-            ]
+    def _shared_zone_page(
+        records: list[Any] | None = None, *, more_coming: bool = False
+    ) -> CKZoneChangesZone:
+        """One page of a shared zone's changes."""
+        if records is None:
+            records = load_invites_fixture("events_query_response.json")["records"]
+        return CKZoneChangesZone.model_validate({
+            "zoneID": {
+                "zoneName": "SHARED-ZONE-FIXTURE",
+                "ownerRecordName": "_shared-owner",
+            },
+            "records": records,
+            "moreComing": more_coming,
+            "syncToken": "FIXTURE-SYNC-TOKEN",
         })
+
+    @classmethod
+    def _shared_zone_changes(cls) -> list[CKZoneChangesZone]:
+        """A single-page shared zone, as iter_changes yields it."""
+        return [cls._shared_zone_page()]
 
     def test_events_returns_dtos_from_private_query(self) -> None:
         """events() returns DTOs populated from the private-scope query."""
@@ -290,14 +300,14 @@ class InvitesServiceTest(unittest.TestCase):
         zone-wide query, while shared has to be enumerated zone by zone.
         """
         query_mock = MagicMock(return_value=self._events_query_response())
-        changes_mock = MagicMock(return_value=self._shared_zone_changes())
+        changes_mock = MagicMock(return_value=iter(self._shared_zone_changes()))
         self._monkeypatch.setattr(self.service.raw, "query", query_mock)
         self._monkeypatch.setattr(
             self.service.raw,
             "zones_list",
             MagicMock(return_value=self._shared_zone_list()),
         )
-        self._monkeypatch.setattr(self.service.raw, "changes", changes_mock)
+        self._monkeypatch.setattr(self.service.raw, "iter_changes", changes_mock)
 
         events = self.service.events()
 
@@ -322,8 +332,8 @@ class InvitesServiceTest(unittest.TestCase):
         )
         self._monkeypatch.setattr(
             self.service.raw,
-            "changes",
-            MagicMock(return_value=self._shared_zone_changes()),
+            "iter_changes",
+            MagicMock(return_value=iter(self._shared_zone_changes())),
         )
 
         self.service.events()
@@ -333,6 +343,40 @@ class InvitesServiceTest(unittest.TestCase):
         self.assertTrue(
             all(call.kwargs.get("zone_wide") for call in query_mock.call_args_list)
         )
+
+    def test_a_shared_zone_is_read_to_its_last_page(self) -> None:
+        """A zone with more behind it must not lose the later pages.
+
+        `changes()` returns one page. Taking only that page dropped events with
+        no sign anything was missing, and a live account with a single small
+        share could never surface it -- `moreComing` is simply false there.
+        """
+        first_records = load_invites_fixture("events_query_response.json")["records"]
+        second = dict(first_records[0])
+        second["recordName"] = "EventDetails:PAGE-TWO-EVENT"
+        pages = [
+            self._shared_zone_page(first_records, more_coming=True),
+            self._shared_zone_page([second]),
+        ]
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "query",
+            MagicMock(return_value=CKQueryResponse.model_validate({"records": []})),
+        )
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "zones_list",
+            MagicMock(return_value=self._shared_zone_list()),
+        )
+        self._monkeypatch.setattr(
+            self.service.raw, "iter_changes", MagicMock(return_value=iter(pages))
+        )
+
+        events = self.service.events()
+
+        # Two from the first page, one from the second.
+        self.assertEqual(len(events), 3)
+        self.assertIn("PAGE-TWO-EVENT", {event.event_id for event in events})
 
     def test_one_unreadable_shared_zone_does_not_hide_the_others(self) -> None:
         """A share we cannot read must not take down the whole listing."""
@@ -357,11 +401,11 @@ class InvitesServiceTest(unittest.TestCase):
         )
         self._monkeypatch.setattr(
             self.service.raw,
-            "changes",
+            "iter_changes",
             MagicMock(
                 side_effect=[
                     InvitesApiError("boom"),
-                    self._shared_zone_changes(),
+                    iter(self._shared_zone_changes()),
                 ]
             ),
         )
@@ -408,6 +452,28 @@ class InvitesServiceTest(unittest.TestCase):
 
         self.assertEqual(zone_id.zoneName, "MISSING-ZONE")
         self.assertIsNone(zone_id.ownerRecordName)
+
+    def test_a_status_code_maps_the_same_as_a_string_or_an_int(self) -> None:
+        """`PyiCloudAPIResponseException.code` is typed `int | str | None`.
+
+        A string "401" compared against the int statuses would fall through to
+        a generic error, so an expired session would look like a server fault.
+        """
+        cases: list[tuple[object, type[Exception]]] = [
+            (401, InvitesAuthError),
+            ("401", InvitesAuthError),
+            (403, InvitesAuthError),
+            (429, InvitesRateLimited),
+            ("429", InvitesRateLimited),
+            (500, InvitesApiError),
+            ("not-a-number", InvitesApiError),
+            (None, InvitesApiError),
+        ]
+        for code, expected in cases:
+            with self.subTest(code=code), self.assertRaises(expected):
+                CloudKitInvitesClient._raise_invites_error(
+                    PyiCloudAPIResponseException("boom", code)  # type: ignore[arg-type]
+                )
 
     def test_a_transport_error_reaches_callers_as_an_invites_error(self) -> None:
         """The session raises before CloudKitHttp can map the status code.


### PR DESCRIPTION
## Proposed change

`InvitesService.events()` raises on every account. It queries both scopes zone-wide, and
CloudKit rejects that against the shared database:

```
Bad Request (400): {
  "serverErrorCode" : "BAD_REQUEST",
  "reason" : "SharedDB does not support Zone Wide queries"
}
```

The shared scope is now enumerated the way CloudKit allows — list the zones shared with the
account, then read each one's changes and keep the `EventDetails` records. Private keeps its
single zone-wide query, which works and is cheaper. A zone that fails to read is skipped
rather than failing the listing, so one unreadable share cannot hide the others.

### Two further things this exposed

**The existing guard never fired.** `_iter_event_details` already wraps the query in
`except InvitesError`, intending to degrade gracefully. It doesn't work: `PyiCloudSession`
raises `PyiCloudAPIResponseException` on a non-ok JSON response, so `CloudKitHttp.post()`
never sees the 4xx it is written to translate, and the transport error reaches callers
untranslated. The invites client now maps it at its own boundary the way the HTTP layer
would have — and at **all five** wrapper methods, not only `query()`, since the others leak
identically.

I scoped that to the invites boundary rather than changing `CloudKitHttp`, because doing it
there would change error types for photos, notes and reminders too. Worth its own
conversation — it means the CloudKit layer's error contract does not currently hold for any
service.

**`event()` could not fetch what `events()` returned.** A shared zone is only addressable
with its original owner, and `_zone_id_req` built every reference without
`ownerRecordName` — a limitation the code already noted in a comment, but unreachable while
`events()` could not return a shared event at all. Fixing the listing made it reachable
immediately: `event()` raised `EventNotFound` for an event `events()` had just returned. The
owner now comes from the shared zones listing, whose `zoneName` is the event id.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:

```python
from pyicloud import PyiCloudService

api = PyiCloudService("jappleseed@apple.com", "password")

for event in api.invites.events():      # previously raised for everyone
    print(event.scope.value, event.title)
```

## Additional information

- This PR fixes or closes issue: #338
- This PR is related to issue:

Cut from `main`, touching only `pyicloud/services/invites/` and `tests/test_invites.py`, so
it is independent of #331, #334, #335, #336 and #337 and merges in any order.

**Testing.** 847 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally — the
workflows trigger only on `main`, so a fork branch has no CI of its own until you approve the
run. Eight of those tests are new, and all eight fail against the previous code; I ran them
against it rather than assuming the new assertions bite.

**One existing test changed.** `test_events_merges_private_and_shared_with_dedup` mocked
`raw.query` as succeeding for the shared scope, which the real API never does — which is
exactly why the suite was green while `events()` failed for every user. It now mocks the
mechanism the shared scope actually uses, and its merge/dedup assertion is unchanged. A
companion test asserts a zone-wide query is never issued against the shared scope again.

**Verified live**, since the whole bug is a shape only the real API produces. I had an event
shared to a test account specifically to exercise this — before the fix the shared scope had
no zones at all, so any implementation would have returned an empty list and looked correct:

| | before | after |
|---|---|---|
| `events()` | raises 400 | 5 events (4 private, 1 shared), keys unique |
| `event(<shared id>)` | unreachable | hydrates, `scope=shared` |
| `rsvps(<shared event>)` | unreachable | 2, matching the RSVP records in the zone |

Shared **writes** still go through the same owner-aware zone reference, which is more correct
than before, but I had no way to exercise a shared write on that account and have not claimed
to.

**Also adds the missing README section.** Invites was the only service without one — Account,
Devices, Find My, Calendar, Contacts, both file stores, Photos, Hide My Email, Reminders and
Notes all have one. It is on this branch rather than its own because the entry point it
documents, `events()`, fails on every account until this fix lands; documenting it against
`main` would describe something that does not work. Happy to split it out if you would rather
review the fix alone.

Every attribute path in the examples was run against the live account rather than read off the
models, which caught one error in my own draft: `participant_status` on `ResolvedShare` is a
plain string, so the `.name` I had written would have raised `AttributeError` for anyone
following it. The section now calls out which fields are strings rather than enums. The two
write calls, `rsvp()` and `accept()`, are documented from their signatures and deliberately
not exercised.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README

