### PR TITLE
fix: raise PyiCloudPCSTimeoutException when PCS retries are exhausted

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -34,6 +34,7 @@ from pyicloud.exceptions import (
     PyiCloudFailedLoginException,
     PyiCloudNoTrustedNumberAvailable,
     PyiCloudPasswordException,
+    PyiCloudPCSTimeoutException,
     PyiCloudServiceNotActivatedException,
     PyiCloudServiceUnavailable,
     PyiCloudTrustedDevicePromptException,
@@ -1223,6 +1224,9 @@ class PyiCloudService:
             else:
                 LOGGER.error("Unknown PCS state: %s", resp["message"])
                 raise PyiCloudAPIResponseException("Unable to request PCS access!")
+
+        LOGGER.error("PCS retries exhausted: %s", resp["message"])
+        raise PyiCloudPCSTimeoutException("Unable to request PCS access!")
 
     def validate_2fa_code(self, code: str) -> bool:
         """Verifies a verification code received via Apple's 2FA system (HSA2)."""

--- a/pyicloud/exceptions.py
+++ b/pyicloud/exceptions.py
@@ -53,6 +53,10 @@ class PyiCloudServiceNotActivatedException(PyiCloudAPIResponseException):
     """iCloud service not activated exception."""
 
 
+class PyiCloudPCSTimeoutException(PyiCloudAPIResponseException):
+    """Raised when PCS access could not be granted after all retries."""
+
+
 class PyiCloudEndpointGoneException(PyiCloudAPIResponseException):
     """Raised when Apple reports an endpoint as permanently gone (HTTP 410).
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,6 +17,7 @@ import requests
 from requests import HTTPError, Response
 
 from pyicloud import PyiCloudService
+import pyicloud.base
 from pyicloud.const import AppleAuthError
 from pyicloud.cookie_jar import PyiCloudCookieJar
 from pyicloud.exceptions import (
@@ -26,6 +27,7 @@ from pyicloud.exceptions import (
     PyiCloudAPIResponseException,
     PyiCloudEndpointGoneException,
     PyiCloudFailedLoginException,
+    PyiCloudPCSTimeoutException,
     PyiCloudServiceNotActivatedException,
     PyiCloudServiceUnavailable,
     PyiCloudTrustedDevicePromptException,
@@ -1922,6 +1924,43 @@ def test_request_pcs_for_service_raises_on_unknown_message(
         patch("pyicloud.base.LOGGER", mock_logger),
     ):
         pyicloud_service._request_pcs_for_service("photos")
+    mock_logger.error.assert_called()
+
+
+def test_request_pcs_for_service_raises_when_retries_exhausted(
+    pyicloud_service: PyiCloudService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test _request_pcs_for_service raises after PCS retries are exhausted."""
+    monkeypatch.setattr(
+        pyicloud_service,
+        "_check_pcs_consent",
+        MagicMock(
+            return_value={"isICDRSDisabled": True, "isDeviceConsentedForPCS": True}
+        ),
+    )
+    pyicloud_service._session = MagicMock()
+    pyicloud_service.params = {}
+    retryable_response: dict[str, str] = {
+        "status": "error",
+        "message": "Requested the device to upload cookies.",
+    }
+    monkeypatch.setattr(
+        pyicloud_service,
+        "_send_pcs_request",
+        MagicMock(return_value=retryable_response),
+    )
+    max_retries: int = pyicloud.base.PCS_MAX_RETRIES
+    mock_logger = MagicMock()
+
+    with (
+        pytest.raises(
+            PyiCloudPCSTimeoutException, match="Unable to request PCS access!"
+        ),
+        patch("time.sleep"),
+        patch("pyicloud.base.LOGGER", mock_logger),
+    ):
+        pyicloud_service._request_pcs_for_service("photos")
+    assert cast(Any, pyicloud_service._send_pcs_request).call_count == max_retries
     mock_logger.error.assert_called()
 
 


### PR DESCRIPTION
## Summary

Fixes #342. When all PCS retry attempts return a retryable message (e.g. `Requested the device to upload cookies.`), `_request_pcs_for_service` previously fell through without raising, letting `RemindersService` be constructed without granted PCS access.

After the retry loop now raises a dedicated `PyiCloudPCSTimeoutException` (a subclass of `PyiCloudAPIResponseException`) so the caller can't proceed without PCS access, matching the intent of PR #317.

## Changes

- **`pyicloud/exceptions.py`**: add `PyiCloudPCSTimeoutException(PyiCloudAPIResponseException)`
- **`pyicloud/base.py`**: raise `PyiCloudPCSTimeoutException` after retries are exhausted
- **`tests/test_base.py`**: add test `test_request_pcs_for_service_raises_when_retries_exhausted`

## Verification

- `ruff check`, `ruff format`, `mypy` clean
- `pytest tests/test_base.py` (165 passed)