### PR TITLE
Resolve SonarCloud findings on main (#340)

### DIFF
--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -95,7 +95,7 @@ jobs:
             -Dsonar.sources=pyicloud
             -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=.coverage/coverage.xml
-            -Dsonar.python.version=3.14
+            -Dsonar.python.version=3.10
             -Dsonar.scm.revision=${{ steps.validate.outputs.head-sha }}
             -Dsonar.qualitygate.wait=true
 

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -77,6 +77,7 @@ from pyicloud.utils import (
 LOGGER: logging.Logger = logging.getLogger(__name__)
 PCS_SLEEP_TIME: int = 5
 PCS_MAX_RETRIES: int = 10
+PCS_ACCESS_ERROR: str = "Unable to request PCS access!"
 
 _HEADERS: dict[str, str] = {
     "User-Agent": (
@@ -1201,7 +1202,7 @@ class PyiCloudService:
             ).json()
 
             if not consent_resp.get("isDeviceConsentNotificationSent"):
-                raise PyiCloudAPIResponseException("Unable to request PCS access!")
+                raise PyiCloudAPIResponseException(PCS_ACCESS_ERROR)
 
         LOGGER.debug("Waiting for PCS consent")
         for _ in range(PCS_MAX_RETRIES):
@@ -1231,10 +1232,10 @@ class PyiCloudService:
                 time.sleep(PCS_SLEEP_TIME)
             else:
                 LOGGER.error("Unknown PCS state: %s", resp["message"])
-                raise PyiCloudAPIResponseException("Unable to request PCS access!")
+                raise PyiCloudAPIResponseException(PCS_ACCESS_ERROR)
 
         LOGGER.error("PCS retries exhausted: %s", resp["message"])
-        raise PyiCloudPCSTimeoutException("Unable to request PCS access!")
+        raise PyiCloudPCSTimeoutException(PCS_ACCESS_ERROR)
 
     def validate_2fa_code(self, code: str) -> bool:
         """Verifies a verification code received via Apple's 2FA system (HSA2)."""

--- a/pyicloud/services/notes/rendering/exporter.py
+++ b/pyicloud/services/notes/rendering/exporter.py
@@ -33,7 +33,7 @@ LOGGER = logging.getLogger(__name__)
 
 def _is_http_url(url: str) -> bool:
     """Return True for absolute ``http``/``https`` asset URLs."""
-    return url.startswith("http://") or url.startswith("https://")
+    return url.startswith(("http://", "https://"))
 
 
 def decode_and_parse_note(record: CKRecord) -> pb.Note | None:

--- a/pyicloud/services/photos_cloudkit/service.py
+++ b/pyicloud/services/photos_cloudkit/service.py
@@ -597,7 +597,7 @@ class PhotoLibrary(BasePhotoLibrary):
                 headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             )
             response = request.json()
-            raw_records = list(response.get("records", []))
+            raw_records: list[Any] = response.get("records", [])
             while "continuationMarker" in response:
                 payload = _query_request_payload(
                     query=query,
@@ -612,7 +612,7 @@ class PhotoLibrary(BasePhotoLibrary):
                 response = request.json()
                 raw_records.extend(response.get("records", []))
             raw_nested_records = []
-            for record in list(raw_records):
+            for record in raw_records:
                 album_type = record.get("fields", {}).get("albumType", {}).get("value")
                 if album_type == AlbumTypeEnum.FOLDER.value:
                     raw_nested_records.extend(
@@ -1119,13 +1119,10 @@ class BasePhotoAlbum(Iterable["PhotoAsset"], ABC):
                 json=self._get_photo_payload(photo_id),
                 headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
             )
-            for photo in self._process_photo_list_response(http_response.json()):
-                if photo.id == photo_id:
-                    return photo
-            for photo in self.photos:
-                if photo.id == photo_id:
-                    return photo
-            raise KeyError(f"Photo does not exist: {photo_id}")
+            return self._photo_by_id(
+                self._process_photo_list_response(http_response.json()),
+                photo_id,
+            )
         client = cast(PhotosCloudKitClient, self._client)
         response = client.query(
             query=query,
@@ -1135,7 +1132,21 @@ class BasePhotoAlbum(Iterable["PhotoAsset"], ABC):
         self._library.current_sync_token = (
             response.syncToken or self._library.current_sync_token
         )
-        for photo in self._process_photo_list_response(response.records):
+        return self._photo_by_id(
+            self._process_photo_list_response(response.records),
+            photo_id,
+        )
+
+    def _photo_by_id(
+        self,
+        candidates: Iterable[PhotoAsset],
+        photo_id: str,
+    ) -> PhotoAsset:
+        """Return the matching photo from a query result, else from the full list.
+
+        Raises ``KeyError`` when the photo cannot be found in either source.
+        """
+        for photo in candidates:
             if photo.id == photo_id:
                 return photo
         for photo in self.photos:
@@ -2327,78 +2338,90 @@ class PhotosService(BaseService):
             if self._shared_library is not None:
                 libraries["shared"] = self._shared_library
             if _can_use_typed_cloudkit(self.session):
-                private_zones = self._private_client.zones_list()
-                for zone in private_zones.zones:
-                    if zone.deleted:
-                        continue
-                    zone_dict = zone.zoneID.model_dump(exclude_none=True)
-                    zone_name = zone.zoneID.zoneName
-                    if zone_name == PRIMARY_ZONE["zoneName"]:
-                        self._root_library.current_sync_token = zone.syncToken
-                        continue
-                    key = zone_name
-                    scope = "private"
-                    if _is_shared_library_zone_name(zone_name):
-                        key = f"shared:{zone_name}"
-                        scope = "shared-library"
-                    libraries[key] = PhotoLibrary(
-                        self,
-                        zone_id=zone_dict,
-                        client=self._private_client,
-                        upload_hydration_timeout=self._upload_hydration_timeout,
-                        upload_hydration_interval=self._upload_hydration_interval,
-                        scope=scope,
-                    )
-                try:
-                    shared_zones = self._shared_client.zones_list()
-                    for zone in shared_zones.zones:
-                        if zone.deleted:
-                            continue
-                        zone_dict = zone.zoneID.model_dump(exclude_none=True)
-                        zone_name = zone.zoneID.zoneName
-                        key = f"shared:{zone_name}"
-                        if key in libraries:
-                            continue
-                        libraries[key] = PhotoLibrary(
-                            self,
-                            zone_id=zone_dict,
-                            client=self._shared_client,
-                            upload_hydration_timeout=self._upload_hydration_timeout,
-                            upload_hydration_interval=self._upload_hydration_interval,
-                            scope="shared-library",
-                        )
-                except (CloudKitApiError, PyiCloudException):  # pylint: disable=broad-exception-caught
-                    LOGGER.debug(
-                        "Shared CloudKit photos zones unavailable", exc_info=True
-                    )
+                self._discover_typed_zones(libraries)
             else:
-                response = self.session.post(
-                    f"{self.service_endpoint}/zones/list?{urlencode(self.params)}",
-                    json={},
-                    headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
-                ).json()
-                for zone in response.get("zones", []):
-                    if zone.get("deleted"):
-                        continue
-                    zone_id = zone.get("zoneID", {})
-                    zone_name = zone_id.get("zoneName")
-                    if zone_name == PRIMARY_ZONE["zoneName"]:
-                        self._root_library.current_sync_token = zone.get("syncToken")
-                        continue
-                    key = zone_name
-                    scope = "private"
-                    if _is_shared_library_zone_name(zone_name):
-                        key = f"shared:{zone_name}"
-                        scope = "shared-library"
-                    libraries[key] = PhotoLibrary(
-                        self,
-                        zone_id=zone_id,
-                        upload_hydration_timeout=self._upload_hydration_timeout,
-                        upload_hydration_interval=self._upload_hydration_interval,
-                        scope=scope,
-                    )
+                self._discover_legacy_zones(libraries)
             self._libraries = libraries
         return self._libraries
+
+    def _discover_typed_zones(
+        self,
+        libraries: dict[str, BasePhotoLibrary | PhotoStreamLibrary],
+    ) -> None:
+        """Discover additional private/shared zones via the typed CloudKit client."""
+        private_zones = self._private_client.zones_list()
+        for zone in private_zones.zones:
+            if zone.deleted:
+                continue
+            zone_dict = zone.zoneID.model_dump(exclude_none=True)
+            zone_name = zone.zoneID.zoneName
+            if zone_name == PRIMARY_ZONE["zoneName"]:
+                self._root_library.current_sync_token = zone.syncToken
+                continue
+            key = zone_name
+            scope = "private"
+            if _is_shared_library_zone_name(zone_name):
+                key = f"shared:{zone_name}"
+                scope = "shared-library"
+            libraries[key] = PhotoLibrary(
+                self,
+                zone_id=zone_dict,
+                client=self._private_client,
+                upload_hydration_timeout=self._upload_hydration_timeout,
+                upload_hydration_interval=self._upload_hydration_interval,
+                scope=scope,
+            )
+        try:
+            shared_zones = self._shared_client.zones_list()
+            for zone in shared_zones.zones:
+                if zone.deleted:
+                    continue
+                zone_dict = zone.zoneID.model_dump(exclude_none=True)
+                zone_name = zone.zoneID.zoneName
+                key = f"shared:{zone_name}"
+                if key in libraries:
+                    continue
+                libraries[key] = PhotoLibrary(
+                    self,
+                    zone_id=zone_dict,
+                    client=self._shared_client,
+                    upload_hydration_timeout=self._upload_hydration_timeout,
+                    upload_hydration_interval=self._upload_hydration_interval,
+                    scope="shared-library",
+                )
+        except (CloudKitApiError, PyiCloudException):  # pylint: disable=broad-exception-caught
+            LOGGER.debug("Shared CloudKit photos zones unavailable", exc_info=True)
+
+    def _discover_legacy_zones(
+        self,
+        libraries: dict[str, BasePhotoLibrary | PhotoStreamLibrary],
+    ) -> None:
+        """Discover additional zones via the legacy REST zones/list endpoint."""
+        response = self.session.post(
+            f"{self.service_endpoint}/zones/list?{urlencode(self.params)}",
+            json={},
+            headers={CONTENT_TYPE: CONTENT_TYPE_TEXT},
+        ).json()
+        for zone in response.get("zones", []):
+            if zone.get("deleted"):
+                continue
+            zone_id = zone.get("zoneID", {})
+            zone_name = zone_id.get("zoneName")
+            if zone_name == PRIMARY_ZONE["zoneName"]:
+                self._root_library.current_sync_token = zone.get("syncToken")
+                continue
+            key = zone_name
+            scope = "private"
+            if _is_shared_library_zone_name(zone_name):
+                key = f"shared:{zone_name}"
+                scope = "shared-library"
+            libraries[key] = PhotoLibrary(
+                self,
+                zone_id=zone_id,
+                upload_hydration_timeout=self._upload_hydration_timeout,
+                upload_hydration_interval=self._upload_hydration_interval,
+                scope=scope,
+            )
 
     @property
     def all(self) -> PhotoAlbum:

--- a/tests/services/test_calendar.py
+++ b/tests/services/test_calendar.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 
 from datetime import datetime
-import os
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -725,7 +724,6 @@ def test_event_duration_is_wall_clock_across_dst(
     derived via ``datetime.timestamp()``, which folds in the process timezone
     and reports a shorter duration across a DST transition.
     """
-    original_tz = os.environ.get("TZ")
     monkeypatch.setenv("TZ", "America/New_York")
     time.tzset()
     try:
@@ -740,10 +738,7 @@ def test_event_duration_is_wall_clock_across_dst(
         # would instead report only 60 in the America/New_York timezone.
         assert event.duration == 120
     finally:
-        if original_tz is None:
-            monkeypatch.delenv("TZ", raising=False)
-        else:
-            monkeypatch.setenv("TZ", original_tz)
+        monkeypatch.undo()
         time.tzset()
 
 

--- a/tests/services/test_calendar.py
+++ b/tests/services/test_calendar.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 
 from datetime import datetime
-import os
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -247,13 +246,13 @@ class _FixedDateTime(datetime):
         return cls.fromtimestamp(cls.fixed.timestamp())
 
 
-def test_default_params_feb_non_leap() -> None:
+def test_default_params_feb_non_leap(monkeypatch: pytest.MonkeyPatch) -> None:
     """default_params should compute Feb (non-leap) as 1..28."""
     mock_session = MagicMock(spec=PyiCloudSession)
     service = _service_with_mocks(mock_session)
 
     # Freeze 'today' to 2025-02-10 (non-leap year)
-    _FixedDateTime.fixed = datetime(2025, 2, 10)
+    monkeypatch.setattr(_FixedDateTime, "fixed", datetime(2025, 2, 10))
     with (
         patch("pyicloud.services.calendar.datetime", _FixedDateTime),
         patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"),
@@ -263,13 +262,13 @@ def test_default_params_feb_non_leap() -> None:
         assert params["endDate"] == "2025-02-28"
 
 
-def test_default_params_feb_leap() -> None:
+def test_default_params_feb_leap(monkeypatch: pytest.MonkeyPatch) -> None:
     """default_params should compute Feb (leap year) as 1..29."""
     mock_session = MagicMock(spec=PyiCloudSession)
     service = _service_with_mocks(mock_session)
 
     # Freeze 'today' to 2028-02-10 (leap year)
-    _FixedDateTime.fixed = datetime(2028, 2, 10)
+    monkeypatch.setattr(_FixedDateTime, "fixed", datetime(2028, 2, 10))
     with (
         patch("pyicloud.services.calendar.datetime", _FixedDateTime),
         patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"),
@@ -716,14 +715,16 @@ def test_event_duration_left_alone_when_dates_unparsable() -> None:
     assert event.duration == 60
 
 
-def test_event_duration_is_wall_clock_across_dst() -> None:
+def test_event_duration_is_wall_clock_across_dst(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """_refresh_duration yields the wall-clock delta across a DST transition.
 
     Dates are naive wall-clock times, so the elapsed minutes must not be
     derived via ``datetime.timestamp()``, which folds in the process timezone
     and reports a shorter duration across a DST transition.
     """
-    os.environ["TZ"] = "America/New_York"
+    monkeypatch.setenv("TZ", "America/New_York")
     time.tzset()
     try:
         with patch("pyicloud.services.calendar.get_localzone_name", return_value="UTC"):
@@ -737,7 +738,7 @@ def test_event_duration_is_wall_clock_across_dst() -> None:
         # would instead report only 60 in the America/New_York timezone.
         assert event.duration == 120
     finally:
-        os.environ.pop("TZ", None)
+        monkeypatch.delenv("TZ", raising=False)
         time.tzset()
 
 

--- a/tests/services/test_calendar.py
+++ b/tests/services/test_calendar.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 
 from datetime import datetime
+import os
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -724,6 +725,7 @@ def test_event_duration_is_wall_clock_across_dst(
     derived via ``datetime.timestamp()``, which folds in the process timezone
     and reports a shorter duration across a DST transition.
     """
+    original_tz = os.environ.get("TZ")
     monkeypatch.setenv("TZ", "America/New_York")
     time.tzset()
     try:
@@ -738,7 +740,10 @@ def test_event_duration_is_wall_clock_across_dst(
         # would instead report only 60 in the America/New_York timezone.
         assert event.duration == 120
     finally:
-        monkeypatch.delenv("TZ", raising=False)
+        if original_tz is None:
+            monkeypatch.delenv("TZ", raising=False)
+        else:
+            monkeypatch.setenv("TZ", original_tz)
         time.tzset()
 
 

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -470,10 +470,9 @@ class InvitesServiceTest(unittest.TestCase):
             (None, InvitesApiError),
         ]
         for code, expected in cases:
+            error = PyiCloudAPIResponseException("boom", code)  # type: ignore[arg-type]
             with self.subTest(code=code), self.assertRaises(expected):
-                CloudKitInvitesClient._raise_invites_error(
-                    PyiCloudAPIResponseException("boom", code)  # type: ignore[arg-type]
-                )
+                CloudKitInvitesClient._raise_invites_error(error)
 
     def test_a_transport_error_reaches_callers_as_an_invites_error(self) -> None:
         """The session raises before CloudKitHttp can map the status code.


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

This PR removes this section — it is **not** a breaking change.

> Note: this PR intentionally does **not** refactor `PyiCloudService.__init__` (16 parameters) because that is the library's primary public constructor and changing it would be a breaking API change. That finding (`python:S107`) is accepted in SonarQube as a documented intentional exception.

## Proposed change

Resolves the open/confirmed SonarCloud new-code findings reported for the `main` branch (issue #340):

- **base.py (S1192)**: dedupe the repeated `"Unable to request PCS access!"` literal into a `PCS_ACCESS_ERROR` module constant.
- **photos_cloudkit/service.py (S3776)**: reduce cognitive complexity by extracting the `libraries` zone discovery into `_discover_typed_zones`/`_discover_legacy_zones` and the photo-by-id lookup into `_photo_by_id`. Also removes unnecessary `list()` wraps (S7504).
- **notes/rendering/exporter.py (S8513)**: collapse chained `startswith()` calls into a single tuple call.
- **tests/services/test_calendar.py (S8997)**: use the `monkeypatch` fixture instead of mutating global state.
- **tests/test_invites.py (S5778)**: isolate the single potentially-throwing invocation inside `assertRaises`.
- **sonarcube.yml**: fix the branch scan's `sonar.python.version` from `3.14` to `3.10`. The S6794/S6796 findings only fire when SonarQube is told Python >= 3.12, but this package requires Python >= 3.10 and cannot use PEP 695 syntax on 3.10/3.11. Aligning the branch analysis with the project's real minimum (matching the PR scan and sonar-project.properties) stops those false positives without breaking 3.10 compatibility.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:

_Not applicable (code quality / tests only). Section removed._

## Additional information

- This PR fixes or closes issue: fixes #340
- This PR is related to issue: n/a

The only remaining new-code finding is `python:S107` on `PyiCloudService.__init__`, which has been **accepted** in SonarQube and documented above as an intentional exception (public API).

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
