### PR TITLE
feat(cli): add an opt-in service probe layer to `icloud doctor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,41 @@ Services Apple advertises that pyicloud does not wrap are listed as
 context rather than as problems, and `--format json` returns the whole
 report, including every finding, for use in bug reports and scripts.
 
+### Probing the services (`--probe`)
+
+The service map only shows what Apple _advertises_. A host can be
+advertised and reachable while the endpoint behind it has been withdrawn,
+which is what happened to the Photos upload endpoint. `--probe` catches
+that by additionally calling each service once with a read-only request:
+
+```console
+icloud doctor --probe
+```
+
+```text
+                             Service probes
+┌─────────────┬─────────────┬────────────────────────────────────┬──────┐
+│ Status      │ Service     │ Read                               │ ms   │
+├─────────────┼─────────────┼────────────────────────────────────┼──────┤
+│ ok          │ account     │ reads storage usage                │ 537  │
+│ ok          │ devices     │ refreshes Find My without locating │ 633  │
+│ unavailable │ files       │ reads the Ubiquity root            │ 83   │
+│ ok          │ reminders   │ reads the reminders sync cursor    │ 336  │
+└─────────────┴─────────────┴────────────────────────────────────┴──────┘
+```
+
+It is opt-in because it makes one real request per service — roughly ten
+seconds in total. Every probe is a GET or the service's own documented
+refresh; none of them writes, and Find My is refreshed without asking your
+devices to report their location.
+
+Two outcomes are shown but do not fail the run, because neither is a
+pyicloud defect: `unavailable` means Apple reports the service as
+unavailable for your account (a Ubiquity library migrated to iCloud Drive,
+for example), and `auth` means the session needs re-authenticating.
+A service whose webservice key was already reported missing is marked
+`skipped` rather than called.
+
 ## Account
 
 You can access information about your iCloud account using the `account` property:

--- a/pyicloud/cli/commands/doctor.py
+++ b/pyicloud/cli/commands/doctor.py
@@ -10,7 +10,7 @@ It is strictly read-only. Nothing here writes to the account.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 from urllib.parse import urlparse
 
 import typer
@@ -31,10 +31,15 @@ from pyicloud.cli.options import (
 )
 from pyicloud.cli.output import console_kv_table, console_table
 from pyicloud.diagnostics import (
+    SERVICE_PROBES,
+    ProbeResult,
+    ProbeStatus,
     WebserviceFinding,
     WebserviceStatus,
     diagnose_webservices,
     environment,
+    probe_failures,
+    probe_services,
     services_at_risk,
     webservice_problems,
 )
@@ -47,6 +52,28 @@ STATUS_LABELS: dict[WebserviceStatus, str] = {
     WebserviceStatus.MALFORMED: "MALFORMED",
     WebserviceStatus.UNUSED: "unused",
 }
+
+PROBE_LABELS: dict[ProbeStatus, str] = {
+    ProbeStatus.OK: "ok",
+    ProbeStatus.UNAVAILABLE: "unavailable",
+    ProbeStatus.AUTH: "auth",
+    ProbeStatus.GONE: "GONE",
+    ProbeStatus.ERROR: "ERROR",
+    ProbeStatus.SKIPPED: "skipped",
+}
+
+ProbeOption = Annotated[
+    bool,
+    typer.Option(
+        "--probe",
+        help=(
+            "Additionally call each service once with a read-only request. "
+            "Catches an endpoint that has been withdrawn behind a host Apple "
+            "still advertises, at the cost of one request per service."
+        ),
+        rich_help_panel="Output & Diagnostics",
+    ),
+]
 
 
 def _session_report(state: CLIState) -> tuple[dict[str, Any], PyiCloudService | None]:
@@ -107,6 +134,18 @@ def _finding_payload(finding: WebserviceFinding) -> dict[str, Any]:
         "url": finding.url,
         "detail": finding.detail,
         "is_problem": finding.is_problem,
+    }
+
+
+def _probe_payload(result: ProbeResult) -> dict[str, Any]:
+    """Render one probe result as JSON-friendly data."""
+
+    return {
+        "service": result.service,
+        "status": result.status.value,
+        "detail": result.detail,
+        "elapsed_ms": result.elapsed_ms,
+        "is_failure": result.is_failure,
     }
 
 
@@ -217,10 +256,45 @@ def _print_webservices(
             state.console.print(f"  {finding.key}: {finding.detail}")
 
 
+def _print_probes(state: CLIState, results: tuple[ProbeResult, ...]) -> None:
+    """Render the probe section."""
+
+    state.console.print(
+        console_table(
+            "Service probes",
+            ["Status", "Service", "Read", "ms"],
+            [
+                (
+                    PROBE_LABELS[result.status],
+                    result.service,
+                    _probe_description(result.service),
+                    result.elapsed_ms or "",
+                )
+                for result in results
+            ],
+        )
+    )
+
+    noteworthy = [result for result in results if result.detail]
+    if noteworthy:
+        state.console.print("\nProbe notes:")
+        for result in noteworthy:
+            state.console.print(f"  {result.service}: {result.detail}")
+
+
+def _probe_description(service: str) -> str:
+    """Return what the probe for a service actually did."""
+
+    return next(
+        (probe.describe for probe in SERVICE_PROBES if probe.service == service), ""
+    )
+
+
 def _print_verdict(
     state: CLIState,
     findings: tuple[WebserviceFinding, ...],
     session: dict[str, Any],
+    probes: tuple[ProbeResult, ...],
 ) -> None:
     """Render the closing line, which is the part that tells the user what to do."""
 
@@ -234,18 +308,32 @@ def _print_verdict(
         return
 
     problems = webservice_problems(findings)
-    if not problems:
+    failed_probes = probe_failures(probes)
+
+    if not problems and not failed_probes:
+        # The wording has to stay honest about what was actually checked: with
+        # no probes, a healthy map is weaker evidence than it sounds.
+        checked = (
+            "Apple is advertising every service this version of pyicloud "
+            "needs, and each one answered."
+            if probes
+            else "Apple is advertising every service this version of pyicloud "
+            "needs. Nothing was called; add --probe to test the endpoints "
+            "themselves."
+        )
         state.console.print(
-            "\nNo problems found. Apple is advertising every service this "
-            "version of pyicloud needs.\nIf something is still failing, the "
-            f"cause is not in the service map — please report it at "
-            f"{ISSUE_TRACKER} and include this output."
+            f"\nNo problems found. {checked}\nIf something is still failing, "
+            f"please report it at {ISSUE_TRACKER} and include this output."
         )
         return
 
-    at_risk = ", ".join(services_at_risk(findings)) or "none"
+    at_risk = sorted({
+        *services_at_risk(findings),
+        *(result.service for result in failed_probes),
+    })
+    count = len(problems) + len(failed_probes)
     state.console.print(
-        f"\n{len(problems)} problem(s) found, affecting: {at_risk}.\n"
+        f"\n{count} problem(s) found, affecting: {', '.join(at_risk) or 'none'}.\n"
         "This is Apple's side rather than your configuration, which usually "
         f"means pyicloud needs updating — please report it at {ISSUE_TRACKER} "
         "and include this output."
@@ -258,15 +346,19 @@ def doctor(  # noqa: PLR0913
     session_dir: SessionDirOption = None,
     http_proxy: HttpProxyOption = None,
     https_proxy: HttpsProxyOption = None,
+    probe: ProbeOption = False,
     no_verify_ssl: NoVerifySslOption = False,
     output_format: OutputFormatOption = DEFAULT_OUTPUT_FORMAT,
     log_level: LogLevelOption = DEFAULT_LOG_LEVEL,
 ) -> None:
     """Check the local install, the session, and Apple's advertised services.
 
-    Read-only: nothing here modifies the account. Exits non-zero when a problem
-    is found, and also when there is no session, since the checks that matter
-    could not be run at all.
+    Read-only: nothing here modifies the account. With --probe it additionally
+    calls each service once, which is the only way to catch an endpoint that
+    has been withdrawn behind a host Apple still advertises.
+
+    Exits non-zero when a problem is found, and also when there is no session,
+    since the checks that matter could not be run at all.
     """
 
     store_command_options(
@@ -294,10 +386,18 @@ def doctor(  # noqa: PLR0913
         else ()
     )
     problems = webservice_problems(findings)
+    # Gated on the session too, for the same reason the findings are: calling
+    # every service with a session that reports unauthenticated would produce
+    # a page of failures that say nothing about the library.
+    probes = (
+        probe_services(api, findings)
+        if (probe and api is not None and authenticated)
+        else ()
+    )
     # Not being logged in is not a defect, but it does mean nothing was
     # verified -- reporting that as success would mislead anything scripting
     # against the exit code.
-    ok = bool(session["authenticated"]) and not problems
+    ok = authenticated and not problems and not probe_failures(probes)
 
     if state.json_output:
         state.write_json({
@@ -305,6 +405,7 @@ def doctor(  # noqa: PLR0913
             "environment": env,
             "session": session,
             "webservices": [_finding_payload(finding) for finding in findings],
+            "probes": [_probe_payload(result) for result in probes],
             "services_at_risk": list(services_at_risk(findings)),
         })
     else:
@@ -314,7 +415,10 @@ def doctor(  # noqa: PLR0913
         if findings:
             state.console.print()
             _print_webservices(state, findings)
-        _print_verdict(state, findings, session)
+        if probes:
+            state.console.print()
+            _print_probes(state, probes)
+        _print_verdict(state, findings, session, probes)
 
     if not ok:
         raise typer.Exit(code=1)

--- a/pyicloud/diagnostics.py
+++ b/pyicloud/diagnostics.py
@@ -15,19 +15,35 @@ it reads a map that authentication has already fetched.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
 import platform
 import sys
-from typing import Any
+import time
+from typing import TYPE_CHECKING, Any
 
 from pyicloud.endpoints import WEBSERVICES, services_using
+from pyicloud.exceptions import (
+    PyiCloudAPIResponseException,
+    PyiCloudAuthRequiredException,
+    PyiCloudFailedLoginException,
+    PyiCloudServiceUnavailable,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle avoidance only
+    from pyicloud.base import PyiCloudService
 
 ACTIVE_STATUS = "active"
 UNKNOWN_VERSION = "unknown"
+
+# Apple answers a withdrawn endpoint with 410 rather than 404, which makes it an
+# unambiguous signal that the library needs updating. Kept local because #334
+# adds the same constant to pyicloud.exceptions; this can defer to it once that
+# merges, and until then the check works on `main` unchanged.
+GONE_STATUS = 410
 
 
 def installed_version() -> str:
@@ -239,3 +255,186 @@ def services_at_risk(
     for finding in webservice_problems(findings):
         at_risk.update(services_using(finding.key))
     return tuple(sorted(at_risk))
+
+
+class ProbeStatus(str, Enum):
+    """The verdict for one service after actually calling it."""
+
+    OK = "ok"
+    UNAVAILABLE = "unavailable"
+    AUTH = "auth"
+    GONE = "gone"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
+#: Probe outcomes that mean the service did not answer as expected.
+PROBE_FAILURES: frozenset[ProbeStatus] = frozenset({
+    ProbeStatus.GONE,
+    ProbeStatus.ERROR,
+})
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeResult:
+    """What one service did when the cheapest available read was made against it."""
+
+    service: str
+    status: ProbeStatus
+    detail: str
+    elapsed_ms: int
+
+    @property
+    def is_failure(self) -> bool:
+        """Return whether this outcome means something is actually broken.
+
+        ``UNAVAILABLE`` and ``AUTH`` are deliberately excluded. A service Apple
+        reports as unavailable for this account -- a migrated Ubiquity library,
+        say -- is account state, and a service asking for re-authentication is
+        the user's session, not a defect. Both are worth showing and neither
+        should fail the run.
+        """
+
+        return self.status in PROBE_FAILURES
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceProbe:
+    """The cheapest read that proves one service answers.
+
+    ``describe`` is shown to the user, because a probe makes a real request and
+    they are entitled to know which one before opting in.
+    """
+
+    service: str
+    describe: str
+    call: Callable[[PyiCloudService], object]
+
+
+def _probe_devices(api: PyiCloudService) -> object:
+    """Refresh Find My without asking the devices to report their location.
+
+    Iterating or counting the manager refreshes with ``locate=True``, which
+    pings the user's hardware. A diagnostic must not do that.
+    """
+
+    api.devices.refresh(locate=False)
+    return "refreshed"
+
+
+#: One read per service property named in the inventory. Each is a GET or the
+#: service's own documented refresh; none of them writes.
+SERVICE_PROBES: tuple[ServiceProbe, ...] = (
+    ServiceProbe("account", "reads storage usage", lambda api: api.account.storage),
+    ServiceProbe(
+        "calendar", "lists calendars", lambda api: api.calendar.get_calendars()
+    ),
+    ServiceProbe(
+        "contacts", "refreshes the contact list", lambda api: api.contacts.all
+    ),
+    ServiceProbe("devices", "refreshes Find My without locating", _probe_devices),
+    ServiceProbe("drive", "reads the Drive root", lambda api: api.drive.root.name),
+    ServiceProbe("files", "reads the Ubiquity root", lambda api: api.files.root),
+    ServiceProbe(
+        "hidemyemail",
+        "counts Hide My Email addresses",
+        lambda api: len(api.hidemyemail),
+    ),
+    ServiceProbe("invites", "lists invite events", lambda api: api.invites.events()),
+    # sync_cursor() rather than a listing for the two zone-backed services: it
+    # is a single token fetch and proves the same reachability. Listing
+    # reminders took 28s against a real account, which is not a diagnostic.
+    ServiceProbe(
+        "notes", "reads the notes sync cursor", lambda api: api.notes.sync_cursor()
+    ),
+    ServiceProbe(
+        "photos", "resolves photo libraries", lambda api: api.photos.libraries
+    ),
+    ServiceProbe(
+        "reminders",
+        "reads the reminders sync cursor",
+        lambda api: api.reminders.sync_cursor(),
+    ),
+)
+
+PROBED_SERVICES: frozenset[str] = frozenset(probe.service for probe in SERVICE_PROBES)
+
+
+def _classify(error: Exception) -> tuple[ProbeStatus, str]:
+    """Map an exception from a probe onto a verdict the user can act on."""
+
+    if isinstance(error, PyiCloudServiceUnavailable):
+        return ProbeStatus.UNAVAILABLE, f"Apple reports this unavailable: {error}"
+    if isinstance(error, PyiCloudFailedLoginException | PyiCloudAuthRequiredException):
+        return ProbeStatus.AUTH, "Needs re-authentication; run `icloud auth login`."
+    if isinstance(error, PyiCloudAPIResponseException) and error.code == GONE_STATUS:
+        return (
+            ProbeStatus.GONE,
+            "Apple no longer serves this endpoint (410); pyicloud needs updating.",
+        )
+    return ProbeStatus.ERROR, f"{type(error).__name__}: {error}"
+
+
+def _blocked_services(findings: tuple[WebserviceFinding, ...]) -> frozenset[str]:
+    """Return services whose webservice key is already known to be unusable.
+
+    Calling these would only restate what the service map already said, in a
+    slower and less specific way.
+    """
+
+    blocked: set[str] = set()
+    for finding in findings:
+        if finding.is_problem:
+            blocked.update(finding.powers)
+    return frozenset(blocked)
+
+
+def probe_services(
+    api: PyiCloudService,
+    findings: tuple[WebserviceFinding, ...] = (),
+) -> tuple[ProbeResult, ...]:
+    """Call each service's cheapest read and report what happened.
+
+    This is the layer the service map cannot cover: a host can be advertised
+    and reachable while the endpoint behind it has been withdrawn. It makes one
+    real request per service, which is why the CLI keeps it behind a flag.
+    """
+
+    blocked = _blocked_services(findings)
+    results: list[ProbeResult] = []
+
+    for probe in SERVICE_PROBES:
+        if probe.service in blocked:
+            results.append(
+                ProbeResult(
+                    service=probe.service,
+                    status=ProbeStatus.SKIPPED,
+                    detail="Its webservice key is already reported above.",
+                    elapsed_ms=0,
+                )
+            )
+            continue
+
+        started = time.monotonic()
+        try:
+            probe.call(api)
+        except Exception as error:  # noqa: BLE001 - a probe must survive anything
+            status, detail = _classify(error)
+        else:
+            status, detail = ProbeStatus.OK, ""
+        results.append(
+            ProbeResult(
+                service=probe.service,
+                status=status,
+                detail=detail,
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+            )
+        )
+
+    return tuple(results)
+
+
+def probe_failures(results: tuple[ProbeResult, ...]) -> tuple[ProbeResult, ...]:
+    """Return only the probe outcomes that mean something is broken."""
+
+    return tuple(result for result in results if result.is_failure)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -13,14 +13,19 @@ from pathlib import Path
 import tempfile
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 from uuid import uuid4
 
 import click
 import pytest
 from typer.testing import CliRunner, Result
 
+from pyicloud.diagnostics import PROBED_SERVICES
 from pyicloud.endpoints import WEBSERVICES
+from pyicloud.exceptions import (
+    PyiCloudAPIResponseException,
+    PyiCloudServiceUnavailable,
+)
 from pyicloud.services.notes.models import Attachment as NoteAttachment
 from pyicloud.services.notes.models import ChangeEvent as NoteChangeEvent
 from pyicloud.services.notes.models import (
@@ -4421,3 +4426,135 @@ def test_doctor_without_a_session_still_reports_what_it_can() -> None:
     assert "Authenticated" in text
     assert "icloud auth login" in text
     assert "report is incomplete" in text
+
+
+def _probing_api(
+    webservices: dict[str, Any] | None = None,
+) -> tuple[FakeAPI, dict[str, MagicMock]]:
+    """Return an authenticated fake plus the service mocks its probes will hit.
+
+    The mocks are handed back rather than read off the fake afterwards: the
+    doctor attaches services `FakeAPI` does not declare, and assertions that
+    reach through the fake for them are neither type- nor lint-checkable.
+    """
+
+    fake_api = _doctor_api(webservices)
+    services = {name: MagicMock() for name in PROBED_SERVICES}
+    services["calendar"].get_calendars.return_value = []
+    services["notes"].sync_cursor.return_value = "cursor"
+    services["reminders"].sync_cursor.return_value = "cursor"
+    services["invites"].events.return_value = []
+    services["hidemyemail"].__len__ = MagicMock(return_value=0)
+    for name, mock in services.items():
+        setattr(fake_api, name, mock)
+    return fake_api, services
+
+
+def test_doctor_does_not_call_any_service_without_the_flag() -> None:
+    """The default run must stay a pure read of already-fetched state."""
+
+    fake_api, services = _probing_api()
+
+    result = _invoke(fake_api, "doctor")
+    text = _unwrapped(result)
+
+    assert result.exit_code == 0
+    services["devices"].refresh.assert_not_called()
+    services["calendar"].get_calendars.assert_not_called()
+    assert "Service probes" not in text
+    # The verdict must not overstate what a map-only run proves.
+    assert "Nothing was called; add --probe" in text
+
+
+def test_doctor_does_not_probe_a_session_that_reports_unauthenticated() -> None:
+    """--probe must be gated on the session, like the map findings already are.
+
+    `api` can be non-null while the status read afterwards says otherwise.
+    Calling all eleven services with that session yields a page of failures
+    that say nothing about the library, under a verdict stating nothing could
+    be checked.
+    """
+
+    fake_api, services = _probing_api()
+    authed = {
+        "authenticated": True,
+        "trusted_session": True,
+        "requires_2fa": False,
+        "requires_2sa": False,
+    }
+    fake_api.get_auth_status = MagicMock(
+        side_effect=[authed, authed, {**authed, "authenticated": False}]
+    )
+
+    result = _invoke(fake_api, "doctor", "--probe", output_format="json")
+    payload = json.loads(result.stdout)
+
+    assert result.exit_code == 1
+    assert payload["probes"] == []
+    services["calendar"].get_calendars.assert_not_called()
+    services["devices"].refresh.assert_not_called()
+
+
+def test_doctor_probe_calls_each_service_and_reports_it() -> None:
+    """--probe adds the section and actually exercises the services."""
+
+    fake_api, services = _probing_api()
+
+    result = _invoke(fake_api, "doctor", "--probe")
+    text = _unwrapped(result)
+
+    assert result.exit_code == 0
+    assert "Service probes" in text
+    assert "each one answered" in text
+    services["calendar"].get_calendars.assert_called_once()
+    # Find My must be refreshed without pinging the user's hardware.
+    services["devices"].refresh.assert_called_once_with(locate=False)
+
+
+def test_doctor_probe_fails_on_a_withdrawn_endpoint() -> None:
+    """A 410 behind a healthy host is exactly what probing exists to catch."""
+
+    fake_api, services = _probing_api()
+    type(services["photos"]).libraries = PropertyMock(
+        side_effect=PyiCloudAPIResponseException("Gone", 410)
+    )
+
+    result = _invoke(fake_api, "doctor", "--probe")
+    text = _unwrapped(result)
+
+    assert result.exit_code == 1
+    assert "GONE" in text
+    assert "affecting: photos" in text
+    assert "pyicloud needs updating" in text
+
+
+def test_doctor_probe_reports_account_state_without_failing() -> None:
+    """A migrated service is the user's account, not a pyicloud defect."""
+
+    fake_api, services = _probing_api()
+    type(services["files"]).root = PropertyMock(
+        side_effect=PyiCloudServiceUnavailable("Account migrated")
+    )
+
+    result = _invoke(fake_api, "doctor", "--probe")
+    text = _unwrapped(result)
+
+    assert result.exit_code == 0
+    assert "unavailable" in text
+    assert "Account migrated" in text
+    assert "each one answered" in text
+
+
+def test_doctor_probe_json_includes_every_result() -> None:
+    """JSON mode carries the probe outcomes alongside the map findings."""
+
+    fake_api, _services = _probing_api()
+    result = _invoke(fake_api, "doctor", "--probe", output_format="json")
+    payload = json.loads(result.stdout)
+
+    assert result.exit_code == 0
+    assert payload["ok"] is True
+    probes = {item["service"]: item for item in payload["probes"]}
+    assert probes["calendar"]["status"] == "ok"
+    assert probes["calendar"]["is_failure"] is False
+    assert set(probes) == set(PROBED_SERVICES)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,18 +8,30 @@ invented ones.
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
 from pyicloud.diagnostics import (
+    PROBED_SERVICES,
+    SERVICE_PROBES,
+    ProbeStatus,
     WebserviceStatus,
     diagnose_webservices,
     environment,
     installed_version,
+    probe_failures,
+    probe_services,
     services_at_risk,
     webservice_problems,
 )
 from pyicloud.endpoints import WEBSERVICES
+from pyicloud.exceptions import (
+    PyiCloudAPIResponseException,
+    PyiCloudAuthRequiredException,
+    PyiCloudFailedLoginException,
+    PyiCloudServiceUnavailable,
+)
 
 
 def _healthy_map() -> dict[str, Any]:
@@ -209,3 +221,160 @@ def test_environment_describes_the_local_install() -> None:
     assert set(report) == {"pyicloud", "python", "platform"}
     assert report["pyicloud"] == installed_version()
     assert all(value for value in report.values())
+
+
+def _probe_api() -> MagicMock:
+    """Return an API whose every probed service answers."""
+
+    api = MagicMock()
+    api.notes.sync_cursor.return_value = "cursor"
+    api.reminders.sync_cursor.return_value = "cursor"
+    api.invites.events.return_value = []
+    api.calendar.get_calendars.return_value = []
+    api.hidemyemail.__len__.return_value = 0
+    return api
+
+
+def test_every_service_in_the_inventory_has_a_probe() -> None:
+    """The probe table and the inventory must not drift apart.
+
+    A service named in the inventory but never probed is a silent gap: the run
+    reports "each one answered" while quietly skipping it. A probe for a
+    service no longer in the inventory is dead code.
+    """
+
+    named_by_inventory = {service for entry in WEBSERVICES for service in entry.powers}
+
+    not_probed = named_by_inventory - PROBED_SERVICES
+    assert not not_probed, (
+        f"named in pyicloud/endpoints.py but never probed: {sorted(not_probed)}. "
+        "Add a probe to SERVICE_PROBES or the run will claim to have checked it."
+    )
+
+    orphaned = PROBED_SERVICES - named_by_inventory
+    assert not orphaned, (
+        f"probed but not named in pyicloud/endpoints.py: {sorted(orphaned)}."
+    )
+
+
+def test_every_probe_describes_what_it_does() -> None:
+    """A probe makes a real request, so it has to say which one."""
+
+    for probe in SERVICE_PROBES:
+        assert probe.describe.strip(), f"{probe.service} does not describe its probe"
+        assert callable(probe.call)
+
+
+def test_probes_report_each_service_answering() -> None:
+    """The happy path returns one OK result per probed service."""
+
+    api = _probe_api()
+
+    results = probe_services(api)
+
+    assert len(results) == len(SERVICE_PROBES)
+    assert all(result.status is ProbeStatus.OK for result in results)
+    assert not probe_failures(results)
+    # A MagicMock answers anything, so the happy path alone cannot tell which
+    # read each probe chose. These pin the two that matter: listing reminders
+    # took 28s against a real account, against 0.3s for the sync cursor.
+    api.reminders.sync_cursor.assert_called_once()
+    api.notes.sync_cursor.assert_called_once()
+    api.reminders.lists.assert_not_called()
+    api.notes.folders.assert_not_called()
+
+
+def test_the_find_my_probe_does_not_ask_devices_to_report_location() -> None:
+    """Counting or iterating Find My devices pings the user's hardware.
+
+    A diagnostic must not cause that as a side effect, so the probe calls
+    refresh(locate=False) explicitly rather than going through the manager's
+    container protocol.
+    """
+
+    api = _probe_api()
+
+    probe_services(api)
+
+    api.devices.refresh.assert_called_once_with(locate=False)
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (PyiCloudServiceUnavailable("Account migrated"), ProbeStatus.UNAVAILABLE),
+        (PyiCloudFailedLoginException("No password set"), ProbeStatus.AUTH),
+        (
+            PyiCloudAuthRequiredException("user@example.com", MagicMock()),
+            ProbeStatus.AUTH,
+        ),
+        (PyiCloudAPIResponseException("Gone", 410), ProbeStatus.GONE),
+        (PyiCloudAPIResponseException("Server error", 500), ProbeStatus.ERROR),
+        (ValueError("something unexpected"), ProbeStatus.ERROR),
+    ],
+)
+def test_a_failing_probe_is_classified(error: Exception, expected: ProbeStatus) -> None:
+    """Each failure shape maps onto a verdict the user can act on."""
+
+    api = _probe_api()
+    type(api).account = PropertyMock(side_effect=error)
+
+    result = next(r for r in probe_services(api) if r.service == "account")
+
+    assert result.status is expected
+    assert result.detail
+
+
+def test_account_state_and_auth_are_reported_but_do_not_fail_the_run() -> None:
+    """A migrated service or an expired session is not a pyicloud defect.
+
+    Both are worth showing -- they answer the user's question -- but neither
+    should make the command report a problem with the library.
+    """
+
+    api = _probe_api()
+    type(api).files = PropertyMock(
+        side_effect=PyiCloudServiceUnavailable("Account migrated")
+    )
+
+    results = probe_services(api)
+    files = next(r for r in results if r.service == "files")
+
+    assert files.status is ProbeStatus.UNAVAILABLE
+    assert not files.is_failure
+    assert not probe_failures(results)
+
+
+def test_a_withdrawn_endpoint_behind_a_healthy_host_fails_the_run() -> None:
+    """The case the service map cannot see, which is why probing exists."""
+
+    api = _probe_api()
+    type(api).photos = PropertyMock(
+        side_effect=PyiCloudAPIResponseException("Gone", 410)
+    )
+
+    results = probe_services(api)
+    photos = next(r for r in results if r.service == "photos")
+
+    assert photos.status is ProbeStatus.GONE
+    assert photos.is_failure
+    assert probe_failures(results) == (photos,)
+
+
+def test_probes_are_skipped_when_the_key_is_already_known_bad() -> None:
+    """Calling a service whose host is missing would only restate the map."""
+
+    advertised = _healthy_map()
+    del advertised["ckdatabasews"]
+    findings = diagnose_webservices(advertised)
+
+    api = _probe_api()
+    results = probe_services(api, findings)
+    by_service = {result.service: result for result in results}
+
+    for service in ("photos", "reminders", "notes", "invites"):
+        assert by_service[service].status is ProbeStatus.SKIPPED
+        assert by_service[service].elapsed_ms == 0
+    # A service whose key is fine is still probed.
+    assert by_service["calendar"].status is ProbeStatus.OK
+    api.photos.assert_not_called()


### PR DESCRIPTION
## Proposed change

`icloud doctor` reads the service map Apple returned at login. That map only shows what Apple
*advertises* — a host can be advertised and perfectly reachable while the endpoint behind it
has been withdrawn, which is exactly what happened in #316. So the map alone would not have
caught the bug the command exists for.

`--probe` closes that gap by calling each service once with a read-only request:

```text
                             Service probes
┌─────────────┬─────────────┬────────────────────────────────────┬──────┐
│ Status      │ Service     │ Read                               │ ms   │
├─────────────┼─────────────┼────────────────────────────────────┼──────┤
│ ok          │ account     │ reads storage usage                │ 703  │
│ ok          │ devices     │ refreshes Find My without locating │ 2760 │
│ unavailable │ files       │ reads the Ubiquity root            │ 138  │
│ ok          │ reminders   │ reads the reminders sync cursor    │ 820  │
└─────────────┴─────────────┴────────────────────────────────────┴──────┘

Probe notes:
  files: Apple reports this unavailable: Account migrated
```

### Four decisions worth reviewing

**Opt-in, and read-only.** Every probe is a GET or the service's own documented refresh; none
writes. It costs one request per service, roughly ten seconds in total, which is why it is
behind a flag rather than on by default.

**Find My is refreshed with `locate=False` deliberately.** Counting or iterating the manager
refreshes with `locate=True`, which pings the user's hardware. A diagnostic must not cause
that as a side effect. There is a test asserting the call.

**Outcomes are separated by whose problem they are.** A withdrawn endpoint or an unexpected
error fails the run. A service Apple reports unavailable for this account — a Ubiquity library
migrated to iCloud Drive, say — or one asking for re-authentication is shown but does not,
because neither is a pyicloud defect. A service whose webservice key was already reported
missing is marked `skipped` rather than called, since doing so would only restate the map more
slowly.

**The probe table cannot drift.** A test asserts it covers exactly the services
`pyicloud/endpoints.py` names, in both directions, so a service can neither go silently
unchecked nor keep a probe after the inventory drops it. I verified it by introducing each
kind of drift rather than assuming it works.

### What the live runs changed

**Listing reminder lists took 28 seconds** against a real account. Both zone-backed services
now read their sync cursor instead — 0.3s, and it proves the same reachability. The
happy-path test asserts *which* read was chosen, because a `MagicMock` answers either and the
test was otherwise passing for no reason.

**The probe layer found a real bug on its first run.** `invites` was the only service to fail
on a healthy account, which turned out to be a zone-wide CloudKit query against the shared
database. That is #338, fixed in #339, and `invites` now reports `ok` — the layer found it and
now confirms it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:

```console
icloud doctor --probe
icloud doctor --probe --format json
```

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #316, the withdrawal this layer is designed to catch

Cut from `main` and independent of #345 and #346.

**Testing.** 952 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally. Twelve are
new.

Verified live: all eleven services answer, `files` reports unavailable without failing the
run, exit code 0 with `--probe` and the honest "Nothing was called; add --probe" wording
without it.

One thing found while rebasing this onto the merged `doctor` command and worth calling out,
since it is the kind of thing a clean auto-merge hides: probing is gated on the session status,
not merely on the API being resolvable. Those two can disagree, and calling eleven services
with a session that reports unauthenticated produces a page of failures that say nothing about
the library — under a verdict stating nothing could be checked. Same gating the map findings
already have, with a test that fails without it.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)
