### PR TITLE
feat(invites): add cancel() and publish() for events you host

### DIFF
--- a/pyicloud/services/invites/service.py
+++ b/pyicloud/services/invites/service.py
@@ -76,6 +76,16 @@ from .models.dto import (
 
 LOGGER = logging.getLogger(__name__)
 
+#: Whether Apple stores each EventDetails flag encrypted. Read off a live
+#: record rather than assumed: they are not uniform -- `isPublished` is
+#: encrypted where `isCancelled` is not -- and sending the wrong one back is
+#: accepted without complaint.
+_ENCRYPTED_EVENT_FLAGS: dict[EventDetailsField, bool] = {
+    EventDetailsField.IS_CANCELLED: False,
+    EventDetailsField.IS_PUBLISHED: True,
+    EventDetailsField.BLOCK_NEW_RSVPS: False,
+}
+
 
 class EventNotFound(InvitesError):
     """Raised when a requested event ID is not present in any scope."""
@@ -293,9 +303,84 @@ class InvitesService(BaseService):
         )
         return self._rsvp_from_modify_response(response, record_name)
 
+    def cancel(self, event: Event, *, cancelled: bool = True) -> Event:
+        """Cancel an event, or reinstate one that was cancelled.
+
+        Only the host can do this; Apple rejects the write for a guest.
+        """
+
+        return self._set_event_flag(event, EventDetailsField.IS_CANCELLED, cancelled)
+
+    def publish(self, event: Event, *, published: bool = True) -> Event:
+        """Publish an event, or return it to a draft state."""
+
+        return self._set_event_flag(event, EventDetailsField.IS_PUBLISHED, published)
+
     # ------------------------------------------------------------------
     # Internal: write helpers
     # ------------------------------------------------------------------
+
+    def _set_event_flag(
+        self, event: Event, field: EventDetailsField, value: bool
+    ) -> Event:
+        """Write one boolean flag on an event's ``EventDetails`` record.
+
+        Apple stores these as INT64 rather than a boolean type, and -- read off
+        a live record rather than assumed -- does not encrypt them uniformly:
+        ``isPublished`` is encrypted where ``isCancelled`` is not. Sending the
+        wrong one back is accepted silently, so the encryption travels with the
+        field rather than being applied to all of them alike.
+        """
+
+        if not event.record_change_tag:
+            raise InvitesApiError(
+                f"Event {event.event_id!r} has no record change tag; fetch it "
+                "via InvitesService.event(...) before writing to it."
+            )
+
+        payload: dict[str, Any] = {"type": "INT64", "value": int(value)}
+        if _ENCRYPTED_EVENT_FLAGS.get(field, False):
+            payload["isEncrypted"] = True
+
+        record_name = f"{EVENT_DETAILS_RECORD_NAME_PREFIX}{event.event_id}"
+        op = CKModifyOperation(
+            operationType="update",
+            record=CKWriteRecord(
+                recordName=record_name,
+                recordType=InvitesRecordType.EventDetails.value,
+                recordChangeTag=event.record_change_tag,
+                fields=cast(CKWriteFields, {field.value: payload}),
+            ),
+        )
+        response: CKModifyResponse = self._raw.modify(
+            self._scope_str(event.scope),
+            operations=[op],
+            zone_id=self._zone_id_req(event.event_id, event.scope),
+            atomic=True,
+        )
+        return self._event_from_modify_response(response, record_name, event.scope)
+
+    def _event_from_modify_response(
+        self, response: CKModifyResponse, record_name: str, scope: EventScope
+    ) -> Event:
+        """Pick the event record out of a modify response and convert it.
+
+        The result carries the new ``record_change_tag``, so a caller can chain
+        writes. Its ``share`` and ``rsvps`` are unset, as in ``events()`` --
+        the modify response returns the EventDetails record alone.
+        """
+
+        for record in response.records:
+            if (
+                isinstance(record, CKRecord)
+                and record.recordName == record_name
+                and record.recordType == InvitesRecordType.EventDetails.value
+            ):
+                return self._event_from_record(record, scope=scope)
+        raise InvitesApiError(
+            f"Modify response did not return {record_name!r}",
+            payload=response.model_dump(mode="json"),
+        )
 
     @staticmethod
     def _current_participant_id(event: Event) -> str:

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -60,6 +60,17 @@ def load_invites_fixture(name: str) -> Any:
 # ---------------------------------------------------------------------------
 
 
+def _written_field(fields: Any, name: str) -> dict[str, Any]:
+    """Return one written field as a plain dict.
+
+    CKWriteRecord parses its fields into models, so a test asserting the wire
+    shape has to come back out through model_dump rather than indexing.
+    """
+
+    value = dict(fields)[name]
+    return value if isinstance(value, dict) else value.model_dump(exclude_none=True)
+
+
 class CodecsTest(unittest.TestCase):
     """Tests for invite codecs."""
 
@@ -452,6 +463,120 @@ class InvitesServiceTest(unittest.TestCase):
 
         self.assertEqual(zone_id.zoneName, "MISSING-ZONE")
         self.assertIsNone(zone_id.ownerRecordName)
+
+    def _hosted_event(self) -> Event:
+        """An event with the change tag a write needs."""
+        return Event(
+            event_id="EVENT-FIXTURE-AAAA",
+            scope=EventScope.PRIVATE,
+            record_change_tag="TAG-1",
+            title="Test event",
+        )
+
+    def _modify_echo(self, fields: dict[str, Any]) -> CKModifyResponse:
+        """A modify response echoing the written record, as Apple returns one."""
+        return CKModifyResponse.model_validate({
+            "records": [
+                {
+                    "recordName": "EventDetails:EVENT-FIXTURE-AAAA",
+                    "recordType": "EventDetails",
+                    "recordChangeTag": "TAG-2",
+                    "fields": fields,
+                }
+            ]
+        })
+
+    def test_cancelling_writes_an_unencrypted_int_flag(self) -> None:
+        """`isCancelled` is INT64 and not encrypted on a live record.
+
+        Apple accepts the wrong encryption flag without complaint, so this is
+        pinned rather than left to the RSVP writer's convention, which encrypts
+        everything.
+        """
+        modify = MagicMock(
+            return_value=self._modify_echo({
+                "isCancelled": {"type": "INT64", "value": 1}
+            })
+        )
+        self._monkeypatch.setattr(self.service.raw, "modify", modify)
+
+        result = self.service.cancel(self._hosted_event())
+
+        written = modify.call_args.kwargs["operations"][0].record
+        self.assertEqual(written.recordType, "EventDetails")
+        self.assertEqual(written.recordName, "EventDetails:EVENT-FIXTURE-AAAA")
+        self.assertEqual(written.recordChangeTag, "TAG-1")
+        field = _written_field(written.fields, "isCancelled")
+        self.assertEqual(field["type"], "INT64")
+        self.assertEqual(field["value"], 1)
+        self.assertIsNone(field.get("isEncrypted"))
+        self.assertTrue(result.is_cancelled)
+
+    def test_publishing_writes_an_encrypted_int_flag(self) -> None:
+        """`isPublished` is encrypted where `isCancelled` is not."""
+        modify = MagicMock(
+            return_value=self._modify_echo({
+                "isPublished": {"type": "INT64", "value": 1, "isEncrypted": True}
+            })
+        )
+        self._monkeypatch.setattr(self.service.raw, "modify", modify)
+
+        self.service.publish(self._hosted_event())
+
+        written = modify.call_args.kwargs["operations"][0].record.fields
+        self.assertIs(_written_field(written, "isPublished")["isEncrypted"], True)
+
+    def test_a_flag_can_be_cleared_as_well_as_set(self) -> None:
+        """Symmetric booleans, so an accidental cancel is recoverable."""
+        modify = MagicMock(
+            return_value=self._modify_echo({
+                "isCancelled": {"type": "INT64", "value": 0}
+            })
+        )
+        self._monkeypatch.setattr(self.service.raw, "modify", modify)
+
+        result = self.service.cancel(self._hosted_event(), cancelled=False)
+
+        written = modify.call_args.kwargs["operations"][0].record.fields
+        self.assertEqual(_written_field(written, "isCancelled")["value"], 0)
+        self.assertFalse(result.is_cancelled)
+
+    def test_the_write_returns_the_new_change_tag(self) -> None:
+        """Callers need it to chain a second write without re-fetching."""
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "modify",
+            MagicMock(
+                return_value=self._modify_echo({
+                    "isCancelled": {"type": "INT64", "value": 1}
+                })
+            ),
+        )
+
+        result = self.service.cancel(self._hosted_event())
+
+        self.assertEqual(result.record_change_tag, "TAG-2")
+
+    def test_writing_without_a_change_tag_is_refused_locally(self) -> None:
+        """A listing does not carry one, and CloudKit would reject the write."""
+        event = Event(event_id="EVENT-FIXTURE-AAAA", scope=EventScope.PRIVATE)
+        modify = MagicMock()
+        self._monkeypatch.setattr(self.service.raw, "modify", modify)
+
+        with self.assertRaises(InvitesApiError):
+            self.service.cancel(event)
+        modify.assert_not_called()
+
+    def test_a_modify_response_without_the_record_is_an_error(self) -> None:
+        """A 200 that does not echo the record back is not a success."""
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "modify",
+            MagicMock(return_value=CKModifyResponse.model_validate({"records": []})),
+        )
+
+        with self.assertRaises(InvitesApiError):
+            self.service.cancel(self._hosted_event())
 
     def test_a_status_code_maps_the_same_as_a_string_or_an_int(self) -> None:
         """`PyiCloudAPIResponseException.code` is typed `int | str | None`.


### PR DESCRIPTION
## Proposed change

The first half of the deferred `EventDetails` writes from #341: `cancel()` and `publish()`.

```python
event = api.invites.event("EVENT-UUID")

api.invites.cancel(event)                    # and cancel(event, cancelled=False)
api.invites.publish(event)                   # and publish(event, published=False)
```

Both are single-field updates on the `EventDetails` record, using the modify path `rsvp()`
already establishes. Symmetric booleans rather than one-way verbs, so an accidental cancel is
recoverable — assuming Apple permits un-cancelling, which is one of the things the testing
note below covers.

### The wire encoding is not what the existing convention suggests

I read it off a live record rather than assuming it. Apple stores these flags as `INT64`, and
**encrypts them inconsistently**:

| field | type | encrypted |
|---|---|---|
| `isPublished` | INT64 | yes |
| `isCancelled` | INT64 | **no** |
| `blockNewRSVPs` | INT64 | no |
| `title` | STRING | yes |

The RSVP writer marks everything `isEncrypted: True`, so following that convention would have
written `isCancelled` wrongly — and Apple accepts the wrong flag without complaint, so nothing
would have surfaced it. The encryption therefore travels with the field in a small map, and
both cases are pinned by tests.

### Two smaller decisions

**A write without a record change tag is refused locally.** `events()` does not populate one —
only `event()` does — and CloudKit would reject the write anyway, with a less useful message
than "fetch it via `event()` first".

**The returned `Event` carries the new change tag**, so a caller can chain a second write
without re-fetching. Its `share` and `rsvps` are unset, as in `events()`, because the modify
response returns the `EventDetails` record alone.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #341, where I proposed this shape

Cut from `main`, touching only `pyicloud/services/invites/service.py` and
`tests/test_invites.py`. Independent of my other open PRs.

**Testing.** 939 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally. Six are
new, and six fail against `main`.

**Not verified live, deliberately.** Every event on my test account has participants — one,
two and four — and cancelling an event notifies them. I am not willing to send real
notifications to real people to exercise a test. Doing this properly needs a disposable event
with no guests; that is the same gap that made the shared-scope read path in #339
unverifiable until one existed, and I would rather say so than quietly ship it as verified.

Two things I therefore cannot yet confirm: whether Apple accepts un-cancelling
(`cancelled=False`), and whether it rejects the write when a guest rather than the host
attempts it. Both are asserted only against mocks here.

**Unrelated bug found while doing this**, filed as #350: `rsvps()` raises for every event you
host, because it issues a per-zone `records/query` that an event's own zone does not support.
I hit it while checking which events had no guests. Not a regression from #339 — it has taken
that path since #246, and was unreachable while `events()` still raised.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)
