### PR TITLE
fix(invites): read RSVPs through zone changes, not a zone query

### DIFF
--- a/pyicloud/services/invites/service.py
+++ b/pyicloud/services/invites/service.py
@@ -156,36 +156,40 @@ class InvitesService(BaseService):
         raise EventNotFound(f"Event not found: {event_id!r}")
 
     def rsvps(self, event: Event) -> list[Rsvp]:
-        """Return the list of RSVPs in an event's zone.
+        """Return the list of RSVPs in an event's zone."""
 
-        Read through the zone's changes rather than by querying it. An event's
-        own zone rejects ``records/query`` with "syncToken operations supported
-        only in SyncZone", so the query this replaces worked only for events
-        shared with you and raised for every event you host.
+        return [
+            self._rsvp_from_record(record)
+            for record in self._rsvp_records(
+                self._scope_str(event.scope),
+                self._zone_id_req(event.event_id, event.scope),
+            )
+        ]
+
+    def _rsvp_records(
+        self, scope_str: ScopeLiteral, zone_id: CKZoneIDReq
+    ) -> list[CKRecord]:
+        """Read a zone's RSVP records through its changes feed.
+
+        Not by querying it: an event's own zone rejects ``records/query`` with
+        "syncToken operations supported only in SyncZone", so the query this
+        replaces worked only for events shared with you.
 
         ``desiredRecordTypes`` asks Apple for the RSVP records alone; the
-        filter below is kept because that projection is a request, not a
-        guarantee.
+        filter is kept because that projection is a request, not a guarantee.
         """
 
         wanted = InvitesRecordType.Rsvp.value
         zone_req = CKZoneChangesZoneReq(
-            zoneID=CKZoneID(
-                **self._zone_id_req(event.event_id, event.scope).model_dump(
-                    exclude_none=True
-                )
-            ),
+            zoneID=CKZoneID(**zone_id.model_dump(exclude_none=True)),
             desiredRecordTypes=[wanted],
         )
-        records = [
+        return [
             record
-            for page in self._raw.iter_changes(
-                self._scope_str(event.scope), zone_req=zone_req
-            )
+            for page in self._raw.iter_changes(scope_str, zone_req=zone_req)
             for record in page.records
             if isinstance(record, CKRecord) and record.recordType == wanted
         ]
-        return [self._rsvp_from_record(record) for record in records]
 
     def resolve(self, short_guid: str) -> ResolvedShare:
         """Preview a share without joining it."""
@@ -515,17 +519,13 @@ class InvitesService(BaseService):
 
         rsvps: tuple[Rsvp, ...] = ()
         try:
-            rsvp_resp = self._raw.query(
-                scope_str,
-                query=CKQueryObject(recordType=InvitesRecordType.Rsvp.value),
-                zone_id=zone_id,
-            )
             rsvps = tuple(
-                self._rsvp_from_record(r) for r in self._records_of(rsvp_resp)
+                self._rsvp_from_record(record)
+                for record in self._rsvp_records(scope_str, zone_id)
             )
         except InvitesError:
             LOGGER.debug(
-                "invites.event.rsvp_query_failed event_id=%s",
+                "invites.event.rsvp_read_failed event_id=%s",
                 event_id,
                 exc_info=True,
             )

--- a/pyicloud/services/invites/service.py
+++ b/pyicloud/services/invites/service.py
@@ -34,6 +34,7 @@ from pyicloud.common.cloudkit import (
     CKWriteFields,
     CKWriteRecord,
     CKZoneChangesZoneReq,
+    CKZoneID,
     CKZoneIDReq,
 )
 from pyicloud.common.cloudkit.base import CloudKitExtraMode
@@ -155,14 +156,36 @@ class InvitesService(BaseService):
         raise EventNotFound(f"Event not found: {event_id!r}")
 
     def rsvps(self, event: Event) -> list[Rsvp]:
-        """Return the list of RSVPs in an event's zone."""
-        zone_id = self._zone_id_req(event.event_id, event.scope)
-        resp = self._raw.query(
-            self._scope_str(event.scope),
-            query=CKQueryObject(recordType=InvitesRecordType.Rsvp.value),
-            zone_id=zone_id,
+        """Return the list of RSVPs in an event's zone.
+
+        Read through the zone's changes rather than by querying it. An event's
+        own zone rejects ``records/query`` with "syncToken operations supported
+        only in SyncZone", so the query this replaces worked only for events
+        shared with you and raised for every event you host.
+
+        ``desiredRecordTypes`` asks Apple for the RSVP records alone; the
+        filter below is kept because that projection is a request, not a
+        guarantee.
+        """
+
+        wanted = InvitesRecordType.Rsvp.value
+        zone_req = CKZoneChangesZoneReq(
+            zoneID=CKZoneID(
+                **self._zone_id_req(event.event_id, event.scope).model_dump(
+                    exclude_none=True
+                )
+            ),
+            desiredRecordTypes=[wanted],
         )
-        return [self._rsvp_from_record(r) for r in self._records_of(resp)]
+        records = [
+            record
+            for page in self._raw.iter_changes(
+                self._scope_str(event.scope), zone_req=zone_req
+            )
+            for record in page.records
+            if isinstance(record, CKRecord) and record.recordType == wanted
+        ]
+        return [self._rsvp_from_record(record) for record in records]
 
     def resolve(self, short_guid: str) -> ResolvedShare:
         """Preview a share without joining it."""

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -525,20 +525,26 @@ class InvitesServiceTest(unittest.TestCase):
         self.assertTrue(all(e.scope is EventScope.PRIVATE for e in events))
 
     def test_event_full_lookup_includes_share_and_rsvps(self) -> None:
-        """A full event lookup returns share and RSVP details."""
-        # Service tries private first; lookup returns event + share, RSVP
-        # query returns one RSVP, OTL query returns empty.
+        """A full event lookup returns share and RSVP details.
+
+        RSVPs come from the zone's changes feed, like `rsvps()`; the one-time
+        link records still come from a query.
+        """
         self._monkeypatch.setattr(
             self.service.raw,
             "lookup",
             MagicMock(return_value=self._event_lookup_response()),
         )
+        rsvp_page = self._rsvp_zone_page(
+            load_invites_fixture("rsvp_query_response.json")["records"]
+        )
+        self._monkeypatch.setattr(
+            self.service.raw, "iter_changes", MagicMock(return_value=iter([rsvp_page]))
+        )
         self._monkeypatch.setattr(
             self.service.raw,
             "query",
-            MagicMock(
-                side_effect=[self._rsvp_query_response(), self._otl_empty_response()]
-            ),
+            MagicMock(return_value=self._otl_empty_response()),
         )
 
         event = self.service.event("EVENT-FIXTURE-AAAA")

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -607,9 +607,17 @@ class InvitesServiceTest(unittest.TestCase):
             self.service.event("NO-SUCH-EVENT")
 
     def test_rsvps_returns_dtos(self) -> None:
-        """rsvps() returns DTOs scoped to the event's private sub-client."""
-        query_mock = MagicMock(return_value=self._rsvp_query_response())
-        self._monkeypatch.setattr(self.service.raw, "query", query_mock)
+        """rsvps() converts the zone's RSVP records into DTOs.
+
+        The fixture is the query response this method used to make; its records
+        are the same shape a zone-changes page returns, so it still describes
+        what Apple sends back.
+        """
+        page = self._rsvp_zone_page(
+            load_invites_fixture("rsvp_query_response.json")["records"]
+        )
+        changes = MagicMock(return_value=iter([page]))
+        self._monkeypatch.setattr(self.service.raw, "iter_changes", changes)
         owner_event = Event(
             event_id="EVENT-FIXTURE-AAAA",
             scope=EventScope.PRIVATE,
@@ -624,10 +632,83 @@ class InvitesServiceTest(unittest.TestCase):
         self.assertEqual(rsvp.status, RsvpStatus.GOING)
         self.assertEqual(rsvp.participant_id, "PARTICIPANT-FIXTURE-GUEST")
         self.assertEqual(rsvp.num_additional_adults, 1)
-        # rsvps() uses the event's scope to pick the right sub-client
-        query_mock.assert_called_once()
-        call = query_mock.call_args
-        self.assertEqual(call.args[0], "private")
+        # The event's scope still picks the sub-client.
+        self.assertEqual(changes.call_args.args[0], "private")
+
+    def _rsvp_zone_page(
+        self,
+        records: list[Any] | None = None,
+        *,
+        extra_types: bool = False,
+        more_coming: bool = False,
+    ) -> CKZoneChangesZone:
+        """One page of a zone's changes, holding an RSVP record."""
+        if records is None:
+            records = [
+                {
+                    "recordName": "P1.rsvp",
+                    "recordType": "RSVP",
+                    "fields": {"name": {"type": "STRING", "value": "Dana"}},
+                }
+            ]
+        if extra_types:
+            # A real zone returns the event and the share alongside the RSVPs.
+            records = [
+                *records,
+                {"recordName": "EventDetails:E", "recordType": "EventDetails"},
+                {"recordName": "cloudkit.zoneshare", "recordType": "cloudkit.share"},
+            ]
+        return CKZoneChangesZone.model_validate({
+            "zoneID": {"zoneName": "EVENT-FIXTURE-AAAA"},
+            "records": records,
+            "moreComing": more_coming,
+            "syncToken": "TOKEN",
+        })
+
+    def test_rsvps_are_read_through_zone_changes_not_a_query(self) -> None:
+        """An event's own zone rejects `records/query`.
+
+        The previous implementation queried the zone, which worked only for
+        events shared with you and returned 400 for every event you host.
+        """
+        query = MagicMock()
+        changes = MagicMock(return_value=iter([self._rsvp_zone_page()]))
+        self._monkeypatch.setattr(self.service.raw, "query", query)
+        self._monkeypatch.setattr(self.service.raw, "iter_changes", changes)
+        event = Event(event_id="EVENT-FIXTURE-AAAA", scope=EventScope.PRIVATE)
+
+        rsvps = self.service.rsvps(event)
+
+        self.assertEqual(len(rsvps), 1)
+        query.assert_not_called()
+        zone_req = changes.call_args.kwargs["zone_req"]
+        self.assertEqual(zone_req.zoneID.zoneName, "EVENT-FIXTURE-AAAA")
+        self.assertEqual(zone_req.desiredRecordTypes, ["RSVP"])
+
+    def test_rsvps_ignores_the_other_records_a_zone_returns(self) -> None:
+        """A zone holds its event and share too; only RSVPs are wanted.
+
+        `desiredRecordTypes` is a request rather than a guarantee, so the
+        filter has to stand on its own.
+        """
+        self._monkeypatch.setattr(
+            self.service.raw,
+            "iter_changes",
+            MagicMock(return_value=iter([self._rsvp_zone_page(extra_types=True)])),
+        )
+        event = Event(event_id="EVENT-FIXTURE-AAAA", scope=EventScope.PRIVATE)
+
+        self.assertEqual(len(self.service.rsvps(event)), 1)
+
+    def test_rsvps_reads_every_page(self) -> None:
+        """A zone with more behind it must not lose the later responses."""
+        pages = [self._rsvp_zone_page(more_coming=True), self._rsvp_zone_page()]
+        self._monkeypatch.setattr(
+            self.service.raw, "iter_changes", MagicMock(return_value=iter(pages))
+        )
+        event = Event(event_id="EVENT-FIXTURE-AAAA", scope=EventScope.SHARED)
+
+        self.assertEqual(len(self.service.rsvps(event)), 2)
 
     def test_resolve_returns_resolved_share(self) -> None:
         """resolve() returns the resolved share details."""


### PR DESCRIPTION
## Proposed change

`InvitesService.rsvps(event)` raises for every event you host. It works only for events shared
*with* you.

It issues a per-zone `records/query`, and an event's own zone rejects that:

```
{
  "serverErrorCode" : "BAD_REQUEST",
  "reason" : "syncToken operations supported only in SyncZone"
}
```

Against a live account, before:

```
private  My cool event        participants=1  -> InvitesApiError: Bad Request (400)
private  My Test Event        participants=4  -> InvitesApiError: Bad Request (400)
private  pyicloud test …      participants=2  -> InvitesApiError: Bad Request (400)
shared   Test event           participants=2  -> 2 rsvp(s)
```

Shared events work because their zones are owned elsewhere; your own event zones do not
support being queried at all.

The changes feed does support them — it is the same mechanism #339 introduced for enumerating
the shared scope, and a per-zone `changes` call returns an event's `EventDetails`, `RSVP` and
`cloudkit.share` records together. `rsvps()` now reads that and filters to `RSVP`.

Two details:

- `desiredRecordTypes` asks Apple for the RSVP records alone, and the filter is kept anyway,
  because a projection is a request rather than a guarantee.
- Paging comes free from `iter_changes()`, which #339 already added and which follows the sync
  token to the end.

**Not a regression from #339.** This path dates from #246. It was simply unreachable while
`events()` raised on every account — nobody got far enough to call `rsvps()`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue: #350
- This PR is related to issue: #339, whose mechanism this reuses

Cut from `main`, touching only `pyicloud/services/invites/service.py` and
`tests/test_invites.py`.

**Testing.** 936 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally. Three are
new and one existing test was rewritten onto the new mechanism — its fixture records are the
same shape a changes page returns, so it still describes what Apple sends. Four fail against
`main`.

**Verified live across both scopes**, which is the part that matters here, since the whole bug
is a difference between them:

```
private  Test event           -> 1 rsvp(s)   ['Jacob Arnould']
private  My cool event        -> 1 rsvp(s)   ['Jacob Arnould']
private  My Test Event        -> 2 rsvp(s)   ['Jacob Arnould', 'Mrjarnould']
private  pyicloud test …      -> 2 rsvp(s)   ['Jacob Arnould', 'mrjarnould']
shared   Test event           -> 2 rsvp(s)   ['Jacob Arnould', <guest>]
```

The shared event returns the same two responses as before, so the path that already worked is
unchanged.

**How I found it.** While building `cancel()` and `publish()` (#351), checking which events had
no guests before testing a write against one. Names in the output above are redacted where they
belong to someone else.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)
