### PR TITLE
fix(cloudkit): surface per-record modify errors instead of discarding them

### DIFF
--- a/pyicloud/common/cloudkit/client.py
+++ b/pyicloud/common/cloudkit/client.py
@@ -16,6 +16,7 @@ from pyicloud.session import PyiCloudSession
 from .base import CloudKitExtraMode, resolve_cloudkit_validation_extra
 from .models import (
     CKDatabaseChangesResponse,
+    CKErrorItem,
     CKLookupDescriptor,
     CKLookupRequest,
     CKLookupResponse,
@@ -265,6 +266,34 @@ class _CloudKitHTTP:
                     close()
 
 
+def _raise_for_record_errors(response: CKModifyResponse) -> None:
+    """Raise when CloudKit reported a per-record failure inside a 200 response.
+
+    CloudKit answers ``200`` for a modify whose records were rejected, and puts
+    the reason in the record entry. Callers looking for their record by name
+    find a ``CKErrorItem`` instead, and every one of them silently skipped it:
+    a rejected write surfaced as a missing record, or as nothing at all.
+
+    Raising here means the reason Apple gave -- "Attempt to save encrypted data
+    in non encrypted field type", say -- reaches the caller instead of being
+    replaced by a guess about the response shape.
+    """
+
+    errors = [record for record in response.records if isinstance(record, CKErrorItem)]
+    if not errors:
+        return
+
+    detail = "; ".join(
+        f"{error.recordName or '<unnamed>'}: {error.serverErrorCode}"
+        + (f" ({error.reason})" if error.reason else "")
+        for error in errors
+    )
+    raise CloudKitApiError(
+        f"CloudKit rejected {len(errors)} record(s) -- {detail}",
+        payload=response.model_dump(mode="json", exclude_none=True),
+    )
+
+
 class CloudKitContainerClient:
     """Typed CloudKit client for a single container/environment/scope."""
 
@@ -436,12 +465,14 @@ class CloudKitContainerClient:
         ).model_dump(mode="json", exclude_none=True)
         data = self._http.post("/records/modify", payload)
         try:
-            return self._validate_response(CKModifyResponse, data)
+            response = self._validate_response(CKModifyResponse, data)
         except ValidationError as exc:
             raise CloudKitApiError(
                 "Modify response validation failed",
                 payload=data,
             ) from exc
+        _raise_for_record_errors(response)
+        return response
 
     def zones_list(self) -> CKZoneListResponse:
         """List the container's zones and return the parsed response."""

--- a/tests/test_cloudkit_client.py
+++ b/tests/test_cloudkit_client.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pyicloud.common.cloudkit import CKQueryObject, CKZoneIDReq
+from pyicloud.common.cloudkit import (
+    CKModifyOperation,
+    CKQueryObject,
+    CKWriteRecord,
+    CKZoneIDReq,
+)
 from pyicloud.common.cloudkit.client import (
     CloudKitApiError,
     CloudKitContainerClient,
@@ -176,3 +181,81 @@ def test_cloudkit_client_download_asset_stream_closes_on_error() -> None:
         list(client.download_asset_stream("https://example.com/asset"))
 
     response.close.assert_called_once()
+
+
+def _modify_op() -> CKModifyOperation:
+    """One trivial update operation, enough to send a modify."""
+
+    return CKModifyOperation(
+        operationType="update",
+        record=CKWriteRecord(recordName="R1", recordType="Thing"),
+    )
+
+
+def test_a_rejected_record_raises_with_apples_reason() -> None:
+    """CloudKit reports write failures per record, inside a 200 response.
+
+    Every caller looked for its record by name, found a CKErrorItem instead of
+    a CKRecord, and skipped it -- so a rejected write surfaced as a missing
+    record or as nothing at all. The reason Apple gave has to reach the caller.
+    """
+
+    session = MagicMock()
+    session.post.return_value = _json_response({
+        "records": [
+            {
+                "recordName": "EventDetails:E1",
+                "serverErrorCode": "BAD_REQUEST",
+                "reason": "Attempt to save encrypted data in non encrypted field type",
+            }
+        ]
+    })
+    client = CloudKitContainerClient("https://example.com/database", session, {})
+
+    with pytest.raises(CloudKitApiError) as exc_info:
+        client.modify(operations=[_modify_op()], zone_id=CKZoneIDReq(zoneName="Z"))
+
+    message = str(exc_info.value)
+    assert "BAD_REQUEST" in message
+    assert "encrypted data in non encrypted field type" in message
+    assert "EventDetails:E1" in message
+
+
+def test_every_rejected_record_is_named() -> None:
+    """A batch that fails in more than one way should say so once."""
+
+    session = MagicMock()
+    session.post.return_value = _json_response({
+        "records": [
+            {"recordName": "A", "serverErrorCode": "BAD_REQUEST", "reason": "bad"},
+            {"recordName": "B", "serverErrorCode": "CONFLICT"},
+        ]
+    })
+    client = CloudKitContainerClient("https://example.com/database", session, {})
+
+    with pytest.raises(CloudKitApiError) as exc_info:
+        client.modify(operations=[_modify_op()], zone_id=CKZoneIDReq(zoneName="Z"))
+
+    message = str(exc_info.value)
+    assert "2 record(s)" in message
+    assert "A: BAD_REQUEST (bad)" in message
+    assert "B: CONFLICT" in message
+
+
+def test_a_successful_modify_still_returns_its_records() -> None:
+    """The guard must not disturb the path that already worked."""
+
+    session = MagicMock()
+    session.post.return_value = _json_response({
+        "records": [
+            {"recordName": "R1", "recordType": "Thing", "recordChangeTag": "TAG"}
+        ]
+    })
+    client = CloudKitContainerClient("https://example.com/database", session, {})
+
+    response = client.modify(
+        operations=[_modify_op()], zone_id=CKZoneIDReq(zoneName="Z")
+    )
+
+    assert len(response.records) == 1
+    assert response.records[0].recordName == "R1"


### PR DESCRIPTION
## Proposed change

CloudKit answers `200` for a modify whose records were rejected, and puts the reason in the
record entry. `CKModifyResponse.records` is already typed
`list[CKRecord | CKTombstoneRecord | CKErrorItem]`, so the error is modelled — but nothing
looked at it.

Every caller scanned for a `CKRecord` with a matching name, did not find one, and reported
something of its own invention. Invites raised "modify response missing record", which reads
like a response-shape problem. Photos filters errors out with an `isinstance` check. Reminders
does not look at all — a caller ignoring the return value would see a silent no-op.

`modify()` now raises `CloudKitApiError` naming every rejected record with Apple's code and
reason, carrying the response as the payload.

### What this recovered, immediately

`InvitesService.rsvp()` reported:

```
RSVP modify response missing record '…_rsvp'
```

What Apple actually said was:

```
CONFLICT (record to insert already exists)
```

An entirely different problem, and it pointed straight at the cause: `rsvp()` chooses between
create and update by looking for the existing response in `event.rsvps`, and event hydration
was silently returning none of them. That is #350, fixed in #352. With both in place the write
takes effect — verified live on an event with no guests, `GOING` → `MAYBE` with a message, and
back.

So the chain was: a rejected query, discarded → empty hydration → wrong operation type → a
rejected write, also discarded → a message about response shape. Two swallowed errors between
the cause and the symptom, and this PR removes the second.

### Scope

Raising rather than collecting, because no caller could have been relying on partial-failure
semantics: none of the three services inspect record errors at all today, so none can
distinguish a partial success from a total one. If a future caller wants per-record outcomes
for a non-atomic batch, the payload carries the full response and the behaviour can be
widened then.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information

- This PR fixes or closes issue: #353
- This PR is related to issue: #350 and #352, whose real cause this made visible

Cut from `main`, touching only `pyicloud/common/cloudkit/client.py` and
`tests/test_cloudkit_client.py`. Independent of my other open PRs, though it and #352 are more
useful together.

**Testing.** 936 tests pass on Python 3.10, 3.11, 3.12, 3.13 and 3.14, run locally. Three are
new: a rejected record surfaces Apple's code and reason, a batch names every rejected record,
and a successful modify is unaffected.

No existing test needed changing, which is itself worth noting: nothing in the suite asserted
the old behaviour, because the old behaviour was to say nothing.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)
